### PR TITLE
Add NODE_TLS_REJECT_UNAUTHORIZED support and introspection fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Apollo Workbench",
   "description": "Tooling to help you develop and mock federated schemas using Apollo Federation",
   "icon": "media/workbench.png",
-  "version": "0.2.31",
+  "version": "0.2.34",
   "publisher": "ApolloGraphQL",
   "engines": {
     "vscode": "^1.34.0"
@@ -38,6 +38,7 @@
     "eslint": "^7.1.0",
     "mocha": "^8.2.1",
     "typescript": "^4.0.2",
+    "vsce": "^1.83.0",
     "vscode-test": "^1.4.1"
   },
   "dependencies": {
@@ -138,6 +139,13 @@
           ],
           "default": true,
           "description": "Specifies whether to display the 'Example Graphs' section is shown in the 'Apollo Studio Graphs' TreeView"
+        },
+        "apollo-workbench.tlsRejectUnauthorized": {
+          "type": [
+            "boolean"
+          ],
+          "default": false,
+          "description": "Specifies whether to set `NODE_TLS_REJECT_UNAUTHORIZED=0` or not. `NODE_TLS_REJECT_UNAUTHORIZED=0` is the default to avoid enterprise cert issues in development - Note this should never be done in production"
         }
       }
     },

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -1,14 +1,19 @@
 import { ApolloGateway, RemoteGraphQLDataSource, GatewayConfig, Experimental_UpdateServiceDefinitions } from "@apollo/gateway";
-import { parse } from 'graphql';
+import { buildClientSchema, getIntrospectionQuery, parse, IntrospectionQuery, printIntrospectionSchema, printSchema } from 'graphql';
 import { Headers } from "apollo-server-env";
 import { ServiceDefinition } from '@apollo/federation';
 import { ServerManager } from "./workbench/serverManager";
 import { FileProvider, WorkbenchUri, WorkbenchUriType } from "./utils/files/fileProvider";
+import { StateManager } from "./workbench/stateManager";
+import { window } from "vscode";
 
 function log(message: string) { console.log(`GATEWAY-${message}`); }
 
 export class OverrideApolloGateway extends ApolloGateway {
     protected async loadServiceDefinitions(config: GatewayConfig): ReturnType<Experimental_UpdateServiceDefinitions> {
+        if (StateManager.settings_tlsRejectUnauthorized) process.env.NODE_TLS_REJECT_UNAUTHORIZED = '';
+        else process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
         let newDefinitions: Array<ServiceDefinition> = [];
 
         let wb = FileProvider.instance.currrentWorkbench;
@@ -40,6 +45,8 @@ export class OverrideApolloGateway extends ApolloGateway {
     }
 
     public static async getTypeDefs(serviceURLOverride: string) {
+        let source = new RemoteGraphQLDataSource({ url: serviceURLOverride, });
+
         try {
             const request = {
                 query: 'query __ApolloGetServiceDefinition__ { _service { sdl } }',
@@ -50,18 +57,43 @@ export class OverrideApolloGateway extends ApolloGateway {
                 },
             };
 
-            let source = new RemoteGraphQLDataSource({ url: serviceURLOverride, });
-
             let { data, errors } = await source.process({ request, context: {} });
             if (data && !errors) {
                 return data._service.sdl as string;
             } else if (errors) {
                 errors.map(error => log(error.message));
+                //If we got errors, it could be that the graphql server running at that url doesn't support Apollo Federation Spec
+                //  In this case, we can try and get the server schema from introspection
+                return await this.getSchemaByIntrospection(serviceURLOverride);
             }
         } catch (err) {
-            log(`Do you have your service running? \n\t${err.message}`)
+            log(`Do you have your service running? \n\t${err.message}`);
+            return await this.getSchemaByIntrospection(serviceURLOverride);
         }
 
         return;
+    }
+
+    private static async getSchemaByIntrospection(serviceURLOverride: string, source?: RemoteGraphQLDataSource) {
+        let introspectionQuery = getIntrospectionQuery();
+        const request = {
+            query: introspectionQuery,
+            http: {
+                url: serviceURLOverride,
+                method: 'POST',
+                headers: new Headers()
+            },
+        };
+        if (!source) source = new RemoteGraphQLDataSource({ url: serviceURLOverride, });
+
+        let { data, errors } = await source.process({ request, context: {} });
+        if (data && !errors) {
+            const schema = buildClientSchema(data as any);
+
+            return printSchema(schema);
+        } else if (errors) {
+            errors.map(error => log(error.message));
+            window.showErrorMessage(`Unable to get the schema from the underlying server running at ${serviceURLOverride}. Your GraphQL server must support the Apollo Federation specification or have introspection enabled`);
+        }
     }
 }

--- a/src/utils/files/fileProvider.ts
+++ b/src/utils/files/fileProvider.ts
@@ -342,6 +342,9 @@ export class FileProvider implements FileSystemProvider {
         }
     }
     async updateSchemaFromUrl(serviceToUpdateUrl: string) {
+        if (StateManager.settings_tlsRejectUnauthorized) process.env.NODE_TLS_REJECT_UNAUTHORIZED = '';
+        else process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
         if (!this.currrentWorkbenchSchemas[serviceToUpdateUrl].url) {
             await this.promptServiceUrl(serviceToUpdateUrl);
         }
@@ -354,9 +357,10 @@ export class FileProvider implements FileSystemProvider {
                 let editor = await window.showTextDocument(WorkbenchUri.parse(serviceToUpdateUrl, WorkbenchUriType.SCHEMAS));
                 if (editor) {
                     const document = editor.document;
-                    editor.edit((editor) => {
+                    await editor.edit((editor) => {
                         editor.replace(new Range(0, 0, document.lineCount, 0), sdl);
-                    })
+                    });
+                    await document.save();
                 }
             }
         } else {//No URL entered for schema

--- a/src/workbench/serverManager.ts
+++ b/src/workbench/serverManager.ts
@@ -23,6 +23,9 @@ export class ServerManager {
     private serversState: { [port: string]: any } = {};
 
     startMocks() {
+        if (StateManager.settings_tlsRejectUnauthorized) process.env.NODE_TLS_REJECT_UNAUTHORIZED = '';
+        else process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
         console.log(`${name}:Setting up mocks`);
         let workbenchFile = FileProvider.instance.currrentWorkbench;
         if (workbenchFile) {

--- a/src/workbench/stateManager.ts
+++ b/src/workbench/stateManager.ts
@@ -63,6 +63,9 @@ export class StateManager {
     static get settings_displayExampleGraphs() {
         return workspace.getConfiguration("apollo-workbench").get('displayExampleGraphs') as boolean;
     }
+    static get settings_tlsRejectUnauthorized() {
+        return workspace.getConfiguration("apollo-workbench").get('tlsRejectUnauthorized') as boolean;
+    }
     private get settings_apolloOrg() {
         return workspace.getConfiguration("apollo-workbench").get('apolloOrg') as string;
     }


### PR DESCRIPTION
- `NODE_TLS_REJECT_UNAUTHORIZED` support added through VSCode settings property `apollo-workbench.tlsRejectUnauthorized`. Use case is for enterprise certs that use this workaround for local development.
- Provide Introspection fallback for gateway implementation for GraphQL servers that don't support the Apollo Federation spec yet (specifically `_service { sdl }`)