### PR TITLE
Running windows support

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
   "dependencies": {
     "@apollo/client": "^3.2.5",
     "@apollo/federation": "^0.23.0",
-    "@apollo/gateway": "^0.25.0",
-    "@apollo/query-planner": "https://8147-252760990-gh.circle-artifacts.com/0/storage/%40apollo/query-planner/query-planner-0.1.0.tgz",
+    "@apollo/gateway": "^0.26.1",
+    "@apollo/query-planner": "^0.1.1",
     "@apollographql/graphql-language-service-interface": "^2.0.2",
     "@types/archiver": "^5.1.0",
     "apollo-language-server": "^1.24.1",

--- a/src/__tests__/suite/helpers.ts
+++ b/src/__tests__/suite/helpers.ts
@@ -24,7 +24,7 @@ export function cleanupWorkbenchFiles() {
     } catch (err) {
         console.log(`Cleanup Error: ${err}`);
     }
-    FileProvider.instance.workbenchFiles.clear();
+    FileProvider.instance.clearWorkbenchFiles();
 }
 
 

--- a/src/commands/studio-operations.ts
+++ b/src/commands/studio-operations.ts
@@ -6,16 +6,17 @@ import { parse } from "graphql";
 import { print } from "graphql";
 
 export async function addToWorkbench(op: StudioOperationTreeItem) {
+    let supergraphs = FileProvider.instance.getWorkbenchFiles();
     let supergraphNames: string[] = [];
-    FileProvider.instance.workbenchFiles.forEach(wbFile => supergraphNames.push(wbFile.graphName));
+    supergraphs.forEach(wbFile => supergraphNames.push(wbFile.graphName));
 
     let supergraphToAddOperationTo = await window.showQuickPick(supergraphNames, { placeHolder: "Select the Supergraph to add the operation to" });
     if (supergraphToAddOperationTo) {
-        let wbFile = Array.from(FileProvider.instance.workbenchFiles.values()).find(wb => wb.graphName == supergraphToAddOperationTo);
+        let wbFile = Array.from(supergraphs.values()).find(wb => wb.graphName == supergraphToAddOperationTo);
         if (wbFile) {
             let wbPath = '';
-            Array.from(FileProvider.instance.workbenchFiles.keys()).forEach(path => {
-                const wb = FileProvider.instance.workbenchFiles.get(path);
+            Array.from(supergraphs.keys()).forEach(path => {
+                const wb = FileProvider.instance.workbenchFileFromPath(path);
                 if (wb?.graphName == supergraphToAddOperationTo && supergraphToAddOperationTo) wbPath = path;
             })
 

--- a/src/graphql/composition.ts
+++ b/src/graphql/composition.ts
@@ -20,7 +20,7 @@ export function superSchemaToSchema(supergraphSchema: string) {
 }
 
 export async function getComposedSchemaLogCompositionErrorsForWbFile(wbFilePath: string) {
-    let workbenchFile = FileProvider.instance.workbenchFiles.get(wbFilePath);
+    let workbenchFile = FileProvider.instance.workbenchFileFromPath(wbFilePath);
     if (workbenchFile) {
         compositionDiagnostics.clear();
         try {

--- a/src/graphql/parsers/csdlParser.ts
+++ b/src/graphql/parsers/csdlParser.ts
@@ -8,7 +8,7 @@ export async function extractDefinedEntitiesByService(wbFilePath: string) {
     let directivesState: { serviceName?: string, keys: { [key: string]: FieldWithType[] } } = { keys: {} };
 
     try {
-        const wbFile = FileProvider.instance.workbenchFiles.get(wbFilePath);
+        const wbFile = FileProvider.instance.workbenchFileFromPath(wbFilePath);
         if (wbFile) {
             let lines = wbFile?.supergraphSdl.split('\n');
 

--- a/src/graphql/parsers/schemaParser.ts
+++ b/src/graphql/parsers/schemaParser.ts
@@ -11,7 +11,7 @@ export function getServiceAvailableTypes(serviceName: string, wbFilePath: string
     let scalars: string[] = [];
 
     try {
-        let localSchema = FileProvider.instance.workbenchFiles.get(wbFilePath)?.schemas[serviceName];
+        let localSchema = FileProvider.instance.workbenchFileFromPath(wbFilePath)?.schemas[serviceName];
         if (localSchema) {
             let doc = parse(localSchema.sdl);
 

--- a/src/workbench/file-system/WorkbenchUri.ts
+++ b/src/workbench/file-system/WorkbenchUri.ts
@@ -16,25 +16,34 @@ export class WorkbenchUri {
     static supergraph(path: string, name?: string, type: WorkbenchUriType = WorkbenchUriType.SUPERGRAPH_SCHEMA): Uri {
         switch (type) {
             case WorkbenchUriType.SCHEMAS:
-                const subgraphPath = resolve(path, 'subgraphs', `${name}.graphql`);
+                let subgraphPath = resolve(path, 'subgraphs', `${name}.graphql`);
+                if (subgraphPath.includes('C:')) subgraphPath = subgraphPath.slice(2).replace(/\\/g, '/');
                 return Uri.parse(`workbench:${subgraphPath}?${name}`);
             case WorkbenchUriType.SCHEMAS_SETTINGS:
-                const schemaSettingPath = resolve(path, 'subgraph-settings', `${name}-settings.json`);
+                let schemaSettingPath = resolve(path, 'subgraph-settings', `${name}-settings.json`);
+                if (schemaSettingPath.includes('C:')) schemaSettingPath = schemaSettingPath.slice(2).replace(/\\/g, '/');
                 return Uri.parse(`workbench:${schemaSettingPath}?${name}`);
             case WorkbenchUriType.QUERIES:
-                const queryPath = resolve(path, 'queries', `${name}.graphql`);
+                let queryPath = resolve(path, 'queries', `${name}.graphql`);
+                if (queryPath.includes('C:')) queryPath = queryPath.slice(2).replace(/\\/g, '/');
                 return Uri.parse(`workbench:${queryPath}?${name}`);
             case WorkbenchUriType.QUERY_PLANS:
-                const queryPlanPath = resolve(path, 'queryplans', `${name}.queryplan`);
+                let queryPlanPath = resolve(path, 'queryplans', `${name}.queryplan`);
+                if (queryPlanPath.includes('C:')) queryPlanPath = queryPlanPath.slice(2).replace(/\\/g, '/');
                 return Uri.parse(`workbench:${queryPlanPath}?${name}`);
             case WorkbenchUriType.SUPERGRAPH_SCHEMA:
-                const superGraphSchemaPath = resolve(path, 'supergraph-schema', `${name}-supergraph.graphql`);
+                let superGraphSchemaPath = resolve(path, 'supergraph-schema', `${name}-supergraph.graphql`);
+                if (superGraphSchemaPath.includes('C:')) superGraphSchemaPath = superGraphSchemaPath.slice(2).replace(/\\/g, '/');
                 return Uri.parse(`workbench:${superGraphSchemaPath}?${name}`);
             case WorkbenchUriType.SUPERGRAPH_API_SCHEMA:
-                const superGraphApiSchemaPath = resolve(path, 'supergraph-api-schema', `${name}-api-schema.graphql`);
+                let superGraphApiSchemaPath = resolve(path, 'supergraph-api-schema', `${name}-api-schema.graphql`);
+                if (superGraphApiSchemaPath.includes('C:')) superGraphApiSchemaPath = superGraphApiSchemaPath.slice(2).replace(/\\/g, '/');
                 return Uri.parse(`workbench:${superGraphApiSchemaPath}?${name}`);
             case WorkbenchUriType.MOCKS:
-                return Uri.parse(resolve(StateManager.instance.extensionGlobalStoragePath ?? '', 'mocks', `${name}-mocks.js`));
+                let subgarphMocksPath = resolve(StateManager.instance.extensionGlobalStoragePath ?? '', 'mocks', `${name}-mocks.js`);
+                if (subgarphMocksPath.toLowerCase().includes('c:')) subgarphMocksPath = subgarphMocksPath.slice(2).replace(/\\/g, '/');
+
+                return Uri.parse(subgarphMocksPath);
         }
     }
 }

--- a/src/workbench/serverManager.ts
+++ b/src/workbench/serverManager.ts
@@ -8,7 +8,7 @@ import { OverrideApolloGateway, GatewayForwardHeadersDataSource } from "../graph
 import { FileProvider } from "./file-system/fileProvider";
 import { extractEntityNames } from "../graphql/parsers/schemaParser";
 import { resolve } from "path";
-import { mkdirSync } from "fs";
+import { mkdirSync, writeFileSync } from "fs";
 import { workspace, Uri, window, StatusBarAlignment, tasks } from "vscode";
 import { execSync } from "child_process";
 import { Disposable } from "vscode-languageclient";
@@ -34,7 +34,7 @@ export class ServerManager {
             const mocksPath = resolve(StateManager.instance.extensionGlobalStoragePath, `mocks`);
             const packageJsonPath = resolve(mocksPath, `package.json`);
             mkdirSync(mocksPath, { recursive: true });
-            workspace.fs.writeFile(Uri.parse(packageJsonPath), Buffer.from('{"name":"mocks", "version":"1.0"}'));
+            writeFileSync(packageJsonPath, '{"name":"mocks", "version":"1.0"}', { encoding: 'utf-8' });
             execSync(`npm i faker`, { cwd: mocksPath });
         }
 
@@ -42,7 +42,7 @@ export class ServerManager {
         else process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
         console.log(`${name}:Setting up mocks`);
-        let workbenchFile = FileProvider.instance.workbenchFiles.get(wbFilePath);
+        let workbenchFile = FileProvider.instance.workbenchFileFromPath(wbFilePath);
         if (workbenchFile) {
             console.log(`${name}:Mocking workbench file: ${workbenchFile.graphName}`);
             FileProvider.instance.loadedWorkbenchFile = workbenchFile;

--- a/src/workbench/tree-data-providers/superGraphTreeDataProvider.ts
+++ b/src/workbench/tree-data-providers/superGraphTreeDataProvider.ts
@@ -23,7 +23,9 @@ export class LocalSupergraphTreeDataProvider implements TreeDataProvider<TreeIte
         if (element == undefined) {
             let items = new Array<TreeItem>();
             const workbenchFiles = FileProvider.instance.refreshLocalWorkbenchFiles();
-            workbenchFiles.forEach((wbFile, wbFilePath) => items.push(new SupergraphTreeItem(wbFile, wbFilePath)));
+            workbenchFiles.forEach((wbFile, wbFilePath) => {
+                items.push(new SupergraphTreeItem(wbFile, wbFilePath));
+            });
 
             if (items.length == 0) {
                 window.showInformationMessage("No workspace files found in current directory", "Create New Workbench").then((value) => {


### PR DESCRIPTION
Query planner package upgrade resolves all dep issues 

Known Issues
- Entity/supergraph schema parsing is broken and will need to be fixed as the new queryplanner uses the `@core` directives