### PR TITLE
chore: fix most lint errors

### DIFF
--- a/src/__tests__/githubCheckTests.ts
+++ b/src/__tests__/githubCheckTests.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const fetch = require('node-fetch');
 import { testRunner } from './testRunner';
 

--- a/src/__tests__/suite/helpers.ts
+++ b/src/__tests__/suite/helpers.ts
@@ -4,14 +4,15 @@ import { readdirSync, unlinkSync } from 'fs';
 import { FileProvider } from '../../workbench/file-system/fileProvider';
 
 export const activateExtension = async () => {
-  return new Promise<void>(async (resolve) => {
-    let extension = vscode.extensions.getExtension(
+  return new Promise<void>((resolve) => {
+    const extension = vscode.extensions.getExtension(
       'ApolloGraphQL.apollo-workbench-vscode',
     );
     if (extension) {
-      await extension.activate();
+      extension.activate().then(resolve);
+    } else {
+      resolve();
     }
-    resolve();
   });
 };
 

--- a/src/__tests__/suite/index.ts
+++ b/src/__tests__/suite/index.ts
@@ -10,7 +10,7 @@ export function run(): Promise<void> {
   });
 
   const testsRoot = path.resolve(__dirname, '..');
-  let isWorkbenchFolderLoaded = StateManager.workspaceRoot ? true : false;
+  const isWorkbenchFolderLoaded = StateManager.workspaceRoot ? true : false;
 
   return new Promise((c, e) => {
     glob('**/**.test.js', { cwd: testsRoot }, (err, files) => {

--- a/src/__tests__/suite/noFolder.test.ts
+++ b/src/__tests__/suite/noFolder.test.ts
@@ -9,5 +9,5 @@ import { ApolloWorkbenchFile } from '../../workbench/file-system/fileTypes';
 suite('No Folder Loaded in Workbnech', () => {
   vscode.window.showInformationMessage('Start all tests.');
   before(activateExtension);
-  after(() => {});
+  after(() => undefined);
 });

--- a/src/__tests__/testRunner.ts
+++ b/src/__tests__/testRunner.ts
@@ -5,7 +5,7 @@ import { runTests } from 'vscode-test';
 //Function for running the tests
 //  @param `loadFolder` will load the testing folder and run the associated tests
 //      default: No folder will be opened and default tests will be ran
-export async function testRunner(loadFolder: boolean = false) {
+export async function testRunner(loadFolder = false) {
   try {
     const extensionDevelopmentPath = path.resolve(__dirname, '../../');
     const extensionTestsPath = path.resolve(__dirname, './suite/index');

--- a/src/commands/extension.ts
+++ b/src/commands/extension.ts
@@ -11,8 +11,8 @@ export async function ensureFolderIsOpen() {
     !workspace.workspaceFolders ||
     (workspace.workspaceFolders && !workspace.workspaceFolders[0])
   ) {
-    let openFolder = 'Open Folder';
-    let response = await window.showErrorMessage(
+    const openFolder = 'Open Folder';
+    const response = await window.showErrorMessage(
       'You must open a folder to create Apollo Workbench files',
       openFolder,
     );
@@ -22,7 +22,7 @@ export async function ensureFolderIsOpen() {
 }
 
 export async function enterStudioApiKey() {
-  let apiKey = await window.showInputBox({
+  const apiKey = await window.showInputBox({
     placeHolder: 'Enter User API Key - user:gh.michael-watson:023jr324tj....',
   });
   if (apiKey && (await isValidKey(apiKey))) {
@@ -42,13 +42,13 @@ export async function gettingStarted(item) {
       commands.executeCommand('workbench.action.closeEditorsInOtherGroups'),
     )
     .then(
-      () => {},
+      () => undefined,
       (e) => console.error(e),
     );
 }
 
 export async function openFolder() {
-  let folder = await window.showOpenDialog({
+  const folder = await window.showOpenDialog({
     canSelectFiles: false,
     canSelectFolders: true,
     canSelectMany: false,

--- a/src/commands/local-supergraph-designs.ts
+++ b/src/commands/local-supergraph-designs.ts
@@ -45,11 +45,11 @@ import { getComposedSchema, superSchemaToSchema } from '../graphql/composition';
 export async function startMocks(item: SubgraphSummaryTreeItem) {
   if (item) ServerManager.instance.startSupergraphMocks(item.filePath);
   else {
-    let wbFiles: string[] = [];
+    const wbFiles: string[] = [];
     FileProvider.instance
       .getWorkbenchFiles()
       .forEach((value, key) => wbFiles.push(value.graphName));
-    let wbFileToStartMocks = await window.showQuickPick(wbFiles, {
+    const wbFileToStartMocks = await window.showQuickPick(wbFiles, {
       placeHolder: 'Select which supergraph design file to mock',
     });
     if (wbFileToStartMocks) {
@@ -106,10 +106,10 @@ export async function viewSubgraphSettings(item: SubgraphTreeItem) {
   );
 }
 export async function addOperation(item: OperationTreeItem) {
-  let wbFilePath = item.filePath;
-  let wbFile = FileProvider.instance.workbenchFileFromPath(wbFilePath);
+  const wbFilePath = item.filePath;
+  const wbFile = FileProvider.instance.workbenchFileFromPath(wbFilePath);
   if (wbFile) {
-    let operationName =
+    const operationName =
       (await window.showInputBox({
         placeHolder: 'Enter a name for the operation',
       })) ?? '';
@@ -124,9 +124,9 @@ export async function addOperation(item: OperationTreeItem) {
   }
 }
 export async function deleteOperation(item: OperationTreeItem) {
-  let wbFilePath = item.filePath;
-  let wbFile = FileProvider.instance.workbenchFileFromPath(wbFilePath);
-  let operationName = item.operationName;
+  const wbFilePath = item.filePath;
+  const wbFile = FileProvider.instance.workbenchFileFromPath(wbFilePath);
+  const operationName = item.operationName;
   if (wbFile) {
     delete wbFile.operations[operationName];
     FileProvider.instance.saveWorkbenchFile(wbFile, item.filePath);
@@ -167,8 +167,8 @@ export function refreshSupergraphs() {
   StateManager.instance.localSupergraphTreeDataProvider.refresh();
 }
 export async function addSubgraph(item: SubgraphSummaryTreeItem) {
-  let wbFile = item.wbFile;
-  let serviceName =
+  const wbFile = item.wbFile;
+  const serviceName =
     (await window.showInputBox({
       placeHolder: 'Enter a unique name for the subgraph',
     })) ?? '';
@@ -186,9 +186,9 @@ export async function addSubgraph(item: SubgraphSummaryTreeItem) {
   }
 }
 export async function deleteSubgraph(item: SubgraphTreeItem) {
-  let wbFilePath = item.wbFilePath;
-  let wbFile = FileProvider.instance.workbenchFileFromPath(wbFilePath);
-  let subgraphName = item.subgraphName;
+  const wbFilePath = item.wbFilePath;
+  const wbFile = FileProvider.instance.workbenchFileFromPath(wbFilePath);
+  const subgraphName = item.subgraphName;
   if (wbFile) {
     delete wbFile.schemas[subgraphName];
     FileProvider.instance.saveWorkbenchFile(wbFile, item.wbFilePath);
@@ -198,7 +198,7 @@ export async function newDesign() {
   if (!StateManager.workspaceRoot) {
     await FileProvider.instance.promptOpenFolder();
   } else {
-    let workbenchName = await window.showInputBox({
+    const workbenchName = await window.showInputBox({
       placeHolder: 'Enter name for workbench file',
     });
     if (!workbenchName) {
@@ -256,14 +256,16 @@ export async function createWorkbenchFromSupergraph(
   }
 }
 async function createWorkbench(graphId: string, selectedVariant: string) {
-  let defaultGraphName = `${graphId}-${selectedVariant}-`;
-  let graphName = await window.showInputBox({
+  const defaultGraphName = `${graphId}-${selectedVariant}-`;
+  const graphName = await window.showInputBox({
     prompt: 'Enter a name for your new workbench file',
     placeHolder: defaultGraphName,
     value: defaultGraphName,
   });
   if (graphName) {
-    let workbenchFile: ApolloWorkbenchFile = new ApolloWorkbenchFile(graphName);
+    const workbenchFile: ApolloWorkbenchFile = new ApolloWorkbenchFile(
+      graphName,
+    );
     workbenchFile.graphName = graphName;
 
     const results = await getGraphSchemasByVariant(
@@ -309,12 +311,12 @@ export async function updateSubgraphSchemaFromURL(item: SubgraphTreeItem) {
     process.env.NODE_TLS_REJECT_UNAUTHORIZED = '';
   else process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
-  let wbFile = FileProvider.instance.workbenchFileFromPath(item.wbFilePath);
+  const wbFile = FileProvider.instance.workbenchFileFromPath(item.wbFilePath);
   if (
     wbFile?.schemas[item.subgraphName] &&
     !wbFile?.schemas[item.subgraphName].url
   ) {
-    let routingURL =
+    const routingURL =
       (await window.showInputBox({
         placeHolder: 'Enter a the url for the schema/service',
       })) ?? '';
@@ -334,7 +336,7 @@ export async function updateSubgraphSchemaFromURL(item: SubgraphTreeItem) {
     if (sdl) {
       wbFile.schemas[item.subgraphName].sdl = sdl;
 
-      let editor = await window.showTextDocument(
+      const editor = await window.showTextDocument(
         WorkbenchUri.supergraph(
           item.wbFilePath,
           item.subgraphName,
@@ -435,7 +437,7 @@ export async function exportSubgraphSchema(item: SubgraphTreeItem) {
 }
 
 export async function exportSubgraphResolvers(item: SubgraphTreeItem) {
-  let exportPath = StateManager.workspaceRoot
+  const exportPath = StateManager.workspaceRoot
     ? resolve(StateManager.workspaceRoot, `${item.subgraphName}-resolvers`)
     : null;
   if (exportPath) {

--- a/src/commands/studio-graphs.ts
+++ b/src/commands/studio-graphs.ts
@@ -35,20 +35,20 @@ export async function switchOrg() {
   if (!StateManager.instance.globalState_userApiKey) await enterStudioApiKey();
 
   let accountId = '';
-  let apiKey = StateManager.instance.globalState_userApiKey;
+  const apiKey = StateManager.instance.globalState_userApiKey;
 
   if (apiKey) {
     const myAccountIds = await getUserMemberships(apiKey);
     const memberships = (myAccountIds?.me as any)?.memberships;
     if (memberships?.length > 1) {
-      let accountMapping: { [key: string]: string } = {};
+      const accountMapping: { [key: string]: string } = {};
       memberships.map((membership) => {
-        let accountId = membership.account.id;
-        let accountName = membership.account.name;
+        const accountId = membership.account.id;
+        const accountName = membership.account.name;
         accountMapping[accountName] = accountId;
       });
 
-      let selectedOrgName =
+      const selectedOrgName =
         (await window.showQuickPick(Object.keys(accountMapping), {
           placeHolder: 'Select an account to load graphs from',
         })) ?? '';

--- a/src/commands/studio-operations.ts
+++ b/src/commands/studio-operations.ts
@@ -6,15 +6,18 @@ import { parse } from 'graphql';
 import { print } from 'graphql';
 
 export async function addToWorkbench(op: StudioOperationTreeItem) {
-  let supergraphs = FileProvider.instance.getWorkbenchFiles();
-  let supergraphNames: string[] = [];
+  const supergraphs = FileProvider.instance.getWorkbenchFiles();
+  const supergraphNames: string[] = [];
   supergraphs.forEach((wbFile) => supergraphNames.push(wbFile.graphName));
 
-  let supergraphToAddOperationTo = await window.showQuickPick(supergraphNames, {
-    placeHolder: 'Select the Supergraph to add the operation to',
-  });
+  const supergraphToAddOperationTo = await window.showQuickPick(
+    supergraphNames,
+    {
+      placeHolder: 'Select the Supergraph to add the operation to',
+    },
+  );
   if (supergraphToAddOperationTo) {
-    let wbFile = Array.from(supergraphs.values()).find(
+    const wbFile = Array.from(supergraphs.values()).find(
       (wb) => wb.graphName == supergraphToAddOperationTo,
     );
     if (wbFile) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -255,8 +255,8 @@ export async function activate(context: ExtensionContext) {
     new ApolloStudioOperationsProvider(),
   );
   workspace.onDidChangeTextDocument((e) => {
-    let uri = e.document.uri;
-    let document = new GraphQLDocument(new Source(e.document.getText()));
+    const uri = e.document.uri;
+    const document = new GraphQLDocument(new Source(e.document.getText()));
     if (uri.scheme == 'workbench') {
       if (uri.path.includes('queries')) {
         const schema = StateManager.instance.workspaceState_schema;
@@ -269,7 +269,7 @@ export async function activate(context: ExtensionContext) {
               }
             }
           }
-          let opDiagnostics = collectExecutableDefinitionDiagnositics(
+          const opDiagnostics = collectExecutableDefinitionDiagnositics(
             schema,
             document,
             fragments,
@@ -277,11 +277,11 @@ export async function activate(context: ExtensionContext) {
           );
           if (opDiagnostics.length > 0) {
             operationDiagnostics.clear();
-            let diagnostics = new Array<Diagnostic>();
+            const diagnostics = new Array<Diagnostic>();
             opDiagnostics.forEach((opDiag) => {
-              let start = opDiag.range.start;
-              let end = opDiag.range.end;
-              let range = new Range(
+              const start = opDiag.range.start;
+              const end = opDiag.range.end;
+              const range = new Range(
                 new Position(start.line, start.character),
                 new Position(end.line, end.character),
               );
@@ -307,7 +307,7 @@ export async function activate(context: ExtensionContext) {
     }
   });
   workspace.onDidSaveTextDocument(async (document) => {
-    let uri = document.uri;
+    const uri = document.uri;
     if (uri.path.includes('mocks')) {
       const querySplit = uri.query.split(':');
       const { wbFile, path } = FileProvider.instance.workbenchFileByGraphName(

--- a/src/graphql/composition.ts
+++ b/src/graphql/composition.ts
@@ -28,7 +28,7 @@ export function superSchemaToSchema(supergraphSchema: string) {
 export async function getComposedSchemaLogCompositionErrorsForWbFile(
   wbFilePath: string,
 ) {
-  let workbenchFile = FileProvider.instance.workbenchFileFromPath(wbFilePath);
+  const workbenchFile = FileProvider.instance.workbenchFileFromPath(wbFilePath);
   if (workbenchFile) {
     compositionDiagnostics.clear();
     try {
@@ -39,8 +39,8 @@ export async function getComposedSchemaLogCompositionErrorsForWbFile(
         console.log('Composition Errors Found:');
 
         console.log(compositionDiagnostics.name);
-        let diagnosticsGroups = handleErrors(workbenchFile, errors);
-        for (var sn in diagnosticsGroups) {
+        const diagnosticsGroups = handleErrors(workbenchFile, errors);
+        for (const sn in diagnosticsGroups) {
           compositionDiagnostics.set(
             WorkbenchUri.supergraph(wbFilePath, sn, WorkbenchUriType.SCHEMAS),
             diagnosticsGroups[sn],
@@ -69,13 +69,13 @@ export async function getComposedSchemaLogCompositionErrorsForWbFile(
 export function getComposedSchema(
   workbenchFile: ApolloWorkbenchFile,
 ): CompositionResult {
-  let sdls: ServiceDefinition[] = [];
-  let errors: GraphQLError[] = [];
-  for (var key in workbenchFile.schemas) {
-    let localSchemaString = workbenchFile.schemas[key].sdl;
+  const sdls: ServiceDefinition[] = [];
+  const errors: GraphQLError[] = [];
+  for (const key in workbenchFile.schemas) {
+    const localSchemaString = workbenchFile.schemas[key].sdl;
     if (localSchemaString) {
       try {
-        let doc = parse(localSchemaString);
+        const doc = parse(localSchemaString);
         //TODO: use onlineParser to find validation
         sdls.push({
           name: key,
@@ -86,13 +86,13 @@ export function getComposedSchema(
         //Need to include any errors for invalid schema
         //TODO: consider using online parser when there is a gql error to get a better placement of the error
         let errorMessage = `Not valid GraphQL Schema: ${err.message}`;
-        let extensions: any = { invalidSchema: true, serviceName: key };
+        const extensions: any = { invalidSchema: true, serviceName: key };
 
         if (err.message.includes('Syntax Error: Unexpected Name ')) {
-          let quotedUnexpected = err.message.split(
+          const quotedUnexpected = err.message.split(
             'Syntax Error: Unexpected Name "',
           )[1];
-          let unexpectedName = quotedUnexpected.slice(
+          const unexpectedName = quotedUnexpected.slice(
             0,
             quotedUnexpected.length - 1,
           );
@@ -108,11 +108,11 @@ export function getComposedSchema(
           err.message.includes('Syntax Error: Expected Name, found ')
         ) {
           errorMessage = `You must define some fields: ${err.message}`;
-          let quotedUnexpected = err.message.split(
+          const quotedUnexpected = err.message.split(
             'Syntax Error: Expected Name, found ',
           )[1];
-          let offset = quotedUnexpected.length == 1 ? 0 : 1;
-          let unexpectedName = quotedUnexpected.slice(
+          const offset = quotedUnexpected.length == 1 ? 0 : 1;
+          const unexpectedName = quotedUnexpected.slice(
             0,
             quotedUnexpected.length - offset,
           );
@@ -134,7 +134,7 @@ export function getComposedSchema(
         );
       }
     } else {
-      let err = 'No schema defined for service';
+      const err = 'No schema defined for service';
       errors.push(
         new GraphQLError(
           err,
@@ -152,7 +152,7 @@ export function getComposedSchema(
     return { errors } as CompositionFailure;
   } else {
     //This blocks UI thread, why I have no clue but it is overworking VS Code
-    let compositionResults = composeAndValidate(sdls);
+    const compositionResults = composeAndValidate(sdls);
 
     if (Object.keys(workbenchFile.schemas).length == 0)
       compositionResults.errors = [
@@ -171,12 +171,12 @@ export function getComposedSchema(
 }
 
 export function handleErrors(wb: ApolloWorkbenchFile, errors: GraphQLError[]) {
-  let schemas = wb.schemas;
-  let diagnosticsGroups: { [key: string]: Diagnostic[] } = {};
+  const schemas = wb.schemas;
+  const diagnosticsGroups: { [key: string]: Diagnostic[] } = {};
 
-  for (var i = 0; i < errors.length; i++) {
-    let error = errors[i];
-    let errorMessage = error.message;
+  for (let i = 0; i < errors.length; i++) {
+    const error = errors[i];
+    const errorMessage = error.message;
     let diagnosticCode = '';
     let typeToIgnore = '';
     let range = new Range(0, 0, 0, 1);
@@ -184,8 +184,8 @@ export function handleErrors(wb: ApolloWorkbenchFile, errors: GraphQLError[]) {
 
     if (error.extensions) {
       if (error.extensions?.noServicesDefined) {
-        let emptySchemas = `"schemas":{}`;
-        let schemasIndex = 0;
+        const emptySchemas = `"schemas":{}`;
+        const schemasIndex = 0;
         range = new Range(
           0,
           schemasIndex,
@@ -197,10 +197,10 @@ export function handleErrors(wb: ApolloWorkbenchFile, errors: GraphQLError[]) {
         error.extensions?.invalidSchema
       ) {
         if (error.extensions.unexpectedName) {
-          let unexpectedName = error.extensions.unexpectedName;
-          let location = error.extensions.locations[0];
-          let lineNumber = location.line - 1;
-          let textIndex = location.column - 1;
+          const unexpectedName = error.extensions.unexpectedName;
+          const location = error.extensions.locations[0];
+          const lineNumber = location.line - 1;
+          const textIndex = location.column - 1;
 
           if (unexpectedName == '[') diagnosticCode = 'makeArray:deleteRange';
           else diagnosticCode = 'deleteRange';
@@ -212,8 +212,8 @@ export function handleErrors(wb: ApolloWorkbenchFile, errors: GraphQLError[]) {
             textIndex + unexpectedName.length,
           );
         } else if (error.extensions.noFieldsDefined) {
-          let location = error.extensions.locations[0];
-          let lineNumber = location.line - 1;
+          const location = error.extensions.locations[0];
+          const lineNumber = location.line - 1;
 
           range = new Range(lineNumber - 1, 0, lineNumber, 0);
         } else {
@@ -223,7 +223,7 @@ export function handleErrors(wb: ApolloWorkbenchFile, errors: GraphQLError[]) {
         }
       } else if (error.extensions?.code) {
         //We have a federation error with code
-        let errSplit = error.message.split('] ');
+        const errSplit = error.message.split('] ');
         serviceName = errSplit[0].substring(1);
 
         switch (error.extensions.code) {
@@ -232,12 +232,12 @@ export function handleErrors(wb: ApolloWorkbenchFile, errors: GraphQLError[]) {
             typeToIgnore = errSplit[1].split(' ->')[0];
             break;
 
-          case 'EXECUTABLE_DIRECTIVES_IN_ALL_SERVICES':
+          case 'EXECUTABLE_DIRECTIVES_IN_ALL_SERVICES': {
             serviceName = '';
-            let services = error.message.split(':')[1].split(',');
+            const services = error.message.split(':')[1].split(',');
             if (services.length > 1)
               services.map((service) => {
-                let sn = service.includes('.')
+                const sn = service.includes('.')
                   ? service.substring(1, service.length - 1)
                   : service.substring(1, service.length);
                 serviceName += `${sn}-:-`;
@@ -246,12 +246,13 @@ export function handleErrors(wb: ApolloWorkbenchFile, errors: GraphQLError[]) {
 
             typeToIgnore = serviceName;
             break;
+          }
         }
       }
     } else if (
       errorMessage.includes('Type Query must define one or more fields')
     ) {
-      let serviceNames = Object.keys(schemas);
+      const serviceNames = Object.keys(schemas);
       if (serviceNames.length >= 1) {
         serviceName = serviceNames[0];
       }
@@ -259,18 +260,18 @@ export function handleErrors(wb: ApolloWorkbenchFile, errors: GraphQLError[]) {
       errorMessage.includes('Field "Query.') ||
       errorMessage.includes('Field "Mutation.')
     ) {
-      let errorNodes = error.nodes ?? [];
-      let fieldName = errorNodes[0].kind;
+      const errorNodes = error.nodes ?? [];
+      const fieldName = errorNodes[0].kind;
       serviceName = '';
-      for (var sn in schemas)
+      for (const sn in schemas)
         if (schemas[sn].sdl.includes(fieldName))
           if (serviceName) serviceName += `${sn}-:-`;
           else serviceName = sn;
     } else if (errorMessage.includes('There can be only one type named')) {
-      let nameNode = error.nodes?.find((n) => n.kind == 'Name') as any;
+      const nameNode = error.nodes?.find((n) => n.kind == 'Name') as any;
       serviceName = '';
 
-      for (var sn in schemas)
+      for (const sn in schemas)
         if (schemas[sn].sdl.includes(nameNode.value)) serviceName += `${sn}-:-`;
 
       typeToIgnore = nameNode.value;
@@ -278,13 +279,13 @@ export function handleErrors(wb: ApolloWorkbenchFile, errors: GraphQLError[]) {
       errorMessage.includes('Field') &&
       errorMessage.includes('can only be defined once')
     ) {
-      let splitMessage = errorMessage.split('.');
+      const splitMessage = errorMessage.split('.');
       typeToIgnore = splitMessage[0].split('"')[1];
     } else if (errorMessage.includes('Unknown type: ')) {
-      let splitMessage = errorMessage.split('"');
-      let fieldType = splitMessage[1];
+      const splitMessage = errorMessage.split('"');
+      const fieldType = splitMessage[1];
 
-      for (var sn in schemas)
+      for (const sn in schemas)
         if (schemas[sn].sdl.includes(typeToIgnore)) serviceName = sn;
 
       // let typeRange = getRangeForFieldNamedType(fieldType, schemas[serviceName].sdl);
@@ -294,7 +295,7 @@ export function handleErrors(wb: ApolloWorkbenchFile, errors: GraphQLError[]) {
     //If we have a typeToIgnore, try getting a valid range for it
     if (typeToIgnore) {
       if (serviceName == 'workbench') {
-        for (var sn in schemas)
+        for (const sn in schemas)
           if (schemas[sn].sdl.includes(typeToIgnore)) serviceName = sn;
       }
 
@@ -306,11 +307,11 @@ export function handleErrors(wb: ApolloWorkbenchFile, errors: GraphQLError[]) {
 
     //If we have multiple services, we'll need to create multiple diagnostics
     if (serviceName.includes('-:-')) {
-      let services = serviceName.split('-:-');
+      const services = serviceName.split('-:-');
       services.map((s) => {
         if (s) {
-          let schema = schemas[s].sdl;
-          let diagnostic = new Diagnostic(
+          const schema = schemas[s].sdl;
+          const diagnostic = new Diagnostic(
             range,
             errorMessage,
             DiagnosticSeverity.Error,
@@ -329,7 +330,7 @@ export function handleErrors(wb: ApolloWorkbenchFile, errors: GraphQLError[]) {
         }
       });
     } else {
-      let diagnostic = new Diagnostic(
+      const diagnostic = new Diagnostic(
         range,
         errorMessage,
         DiagnosticSeverity.Error,

--- a/src/graphql/graphClient.ts
+++ b/src/graphql/graphClient.ts
@@ -95,23 +95,23 @@ const getGraphOperations = gql`
 `;
 
 export async function isValidKey(apiKey: string) {
-  let result = await toPromise(
+  const result = await toPromise(
     execute(createLink({ apiKey }), { query: keyCheck }),
   );
-  let data = result.data as CheckUserApiKey;
+  const data = result.data as CheckUserApiKey;
   if ((data.me as CheckUserApiKey_me_User)?.id) return true;
   return false;
 }
 
 export async function getUserMemberships(apiKey: string) {
-  let result = await toPromise(
+  const result = await toPromise(
     execute(createLink({ apiKey }), { query: userMemberships }),
   );
   return result.data as UserMemberships;
 }
 
 export async function getAccountGraphs(apiKey: string, accountId: string) {
-  let result = await toPromise(
+  const result = await toPromise(
     execute(createLink({ apiKey, accountId }), {
       query: accountServiceVariants,
       variables: {
@@ -127,8 +127,8 @@ export async function getGraphOps(
   graphId: string,
   graphVariant: string,
 ) {
-  let days = StateManager.settings_daysOfOperationsToFetch;
-  let result = await toPromise(
+  const days = StateManager.settings_daysOfOperationsToFetch;
+  const result = await toPromise(
     execute(createLink({ apiKey, graphId, graphVariant }), {
       query: getGraphOperations,
       variables: {
@@ -146,7 +146,7 @@ export async function getGraphSchemasByVariant(
   graphId: string,
   graphVariant: string,
 ) {
-  let result = await toPromise(
+  const result = await toPromise(
     execute(createLink({ apiKey, graphId, graphVariant }), {
       query: getGraphSchemas,
       variables: {
@@ -158,6 +158,7 @@ export async function getGraphSchemasByVariant(
   return result.data as GetGraphSchemas;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const { version } = require('../../package.json');
 interface CreateLinkOptions {
   apiKey: string;
@@ -166,8 +167,8 @@ interface CreateLinkOptions {
   graphVariant?: string;
 }
 function createLink(options: CreateLinkOptions) {
-  let userId = options.apiKey.split(':')[1];
-  let headers = {
+  const userId = options.apiKey.split(':')[1];
+  const headers = {
     'x-api-key': options.apiKey,
     'studio-user-id': userId,
     'apollographql-client-name': 'Apollo Workbench',

--- a/src/graphql/graphRouter.ts
+++ b/src/graphql/graphRouter.ts
@@ -28,7 +28,7 @@ function log(message: string) {
 }
 
 export class GatewayForwardHeadersDataSource extends RemoteGraphQLDataSource {
-  serviceName: string = '';
+  serviceName = '';
   willSendRequest({ request, context }) {
     StateManager.settings_headersToForwardFromGateway.forEach((key) => {
       if (context.incomingHeaders[key])
@@ -39,7 +39,7 @@ export class GatewayForwardHeadersDataSource extends RemoteGraphQLDataSource {
         );
     });
 
-    let service =
+    const service =
       FileProvider.instance.loadedWorkbenchFile?.schemas[this.serviceName];
     if (service) {
       service.requiredHeaders?.forEach((requiredHeader) => {
@@ -63,19 +63,19 @@ export class OverrideApolloGateway extends ApolloGateway {
       process.env.NODE_TLS_REJECT_UNAUTHORIZED = '';
     else process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
-    let newDefinitions: Array<ServiceDefinition> = [];
+    const newDefinitions: Array<ServiceDefinition> = [];
 
-    let wb = FileProvider.instance.loadedWorkbenchFile;
+    const wb = FileProvider.instance.loadedWorkbenchFile;
     if (wb) {
-      for (var serviceName in wb.schemas) {
+      for (const serviceName in wb.schemas) {
         const service = wb.schemas[serviceName];
 
         if (service.shouldMock) {
-          let typeDefs = parse(service.sdl);
-          let url = `http://localhost:${ServerManager.instance.portMapping[serviceName]}`;
+          const typeDefs = parse(service.sdl);
+          const url = `http://localhost:${ServerManager.instance.portMapping[serviceName]}`;
           newDefinitions.push({ name: serviceName, url, typeDefs });
         } else {
-          let typeDefs = await OverrideApolloGateway.getTypeDefs(
+          const typeDefs = await OverrideApolloGateway.getTypeDefs(
             service.url as string,
             serviceName,
           );
@@ -118,11 +118,11 @@ export class OverrideApolloGateway extends ApolloGateway {
     serviceURLOverride: string,
     serviceName: string,
   ) {
-    let source = new RemoteGraphQLDataSource({ url: serviceURLOverride });
-    let requiredHeaders =
+    const source = new RemoteGraphQLDataSource({ url: serviceURLOverride });
+    const requiredHeaders =
       FileProvider.instance.loadedWorkbenchFile?.schemas[serviceName]
         ?.requiredHeaders;
-    let headers = new Headers();
+    const headers = new Headers();
     requiredHeaders?.forEach((requiredHeader) => {
       if (requiredHeader && requiredHeader.value)
         headers.append(requiredHeader.key, requiredHeader.value);
@@ -138,7 +138,7 @@ export class OverrideApolloGateway extends ApolloGateway {
         },
       };
 
-      let { data, errors } = await source.process({ request, context: {} });
+      const { data, errors } = await source.process({ request, context: {} });
       if (data && !errors) {
         return data._service.sdl as string;
       } else if (errors) {
@@ -174,7 +174,7 @@ export class OverrideApolloGateway extends ApolloGateway {
     source: RemoteGraphQLDataSource,
     requiredHeaders: Headers,
   ) {
-    let introspectionQuery = getIntrospectionQuery();
+    const introspectionQuery = getIntrospectionQuery();
     const request = {
       query: introspectionQuery,
       http: {
@@ -184,7 +184,7 @@ export class OverrideApolloGateway extends ApolloGateway {
       },
     };
 
-    let { data, errors } = await source.process({ request, context: {} });
+    const { data, errors } = await source.process({ request, context: {} });
     if (data && !errors) {
       const schema = buildClientSchema(data as any);
 

--- a/src/graphql/parsers/csdlParser.ts
+++ b/src/graphql/parsers/csdlParser.ts
@@ -25,37 +25,38 @@ function getFieldTypeString(field): string {
         case 'NamedType':
           return `${field.type.name.value}!`;
       }
+      return '';
     default:
       return '';
   }
 }
 
 export async function extractDefinedEntitiesByService(wbFilePath: string) {
-  let extendables: {
+  const extendables: {
     [serviceName: string]: {
       type: string;
       keys: { [key: string]: FieldWithType[] };
     }[];
   } = {};
-  let joinGraphEnumValues: { [joinGraphEnum: string]: string } = {};
+  const joinGraphEnumValues: { [joinGraphEnum: string]: string } = {};
 
   try {
     const wbFile = FileProvider.instance.workbenchFileFromPath(wbFilePath);
     if (wbFile) {
       visit(parse(wbFile.supergraphSdl), {
         ObjectTypeDefinition(node) {
-          let joinOwnerDirective = node.directives?.find(
+          const joinOwnerDirective = node.directives?.find(
             (d) => d.name.value == 'join__owner',
           );
           if (joinOwnerDirective && joinOwnerDirective.arguments) {
-            let joinGraphEnumValue = ((joinOwnerDirective
+            const joinGraphEnumValue = ((joinOwnerDirective
               .arguments[0] as ArgumentNode).value as EnumValueNode).value;
-            let entity: {
+            const entity: {
               type: string;
               keys: { [key: string]: FieldWithType[] };
             } = { type: node.name.value, keys: {} };
 
-            let joinKeyDirectives = node.directives?.filter(
+            const joinKeyDirectives = node.directives?.filter(
               (d) =>
                 d.name.value == 'join__type' &&
                 (d.arguments?.find(
@@ -66,15 +67,15 @@ export async function extractDefinedEntitiesByService(wbFilePath: string) {
             );
             if (joinKeyDirectives) {
               joinKeyDirectives?.forEach((jkd) => {
-                let keyBlock = (jkd.arguments?.find(
+                const keyBlock = (jkd.arguments?.find(
                   (a) => a.name.value == 'key',
                 )?.value as StringValueNode).value;
-                let parsedFields: string[] = [];
+                const parsedFields: string[] = [];
                 let startIndex = -1;
                 let notComposite = true;
-                for (var i = 0; i < keyBlock.length; i++) {
+                for (let i = 0; i < keyBlock.length; i++) {
                   let lastParsedField = '';
-                  let char = keyBlock[i];
+                  const char = keyBlock[i];
                   switch (char) {
                     case ' ':
                       if (startIndex != -1 && notComposite) {
@@ -101,8 +102,8 @@ export async function extractDefinedEntitiesByService(wbFilePath: string) {
                 }
 
                 parsedFields.forEach((parsedField) => {
-                  let finalKey = keyBlock.trim();
-                  let field = node.fields?.find(
+                  const finalKey = keyBlock.trim();
+                  const field = node.fields?.find(
                     (f) => f.name.value == parsedField,
                   );
                   let fieldType = '';

--- a/src/graphql/parsers/schemaParser.ts
+++ b/src/graphql/parsers/schemaParser.ts
@@ -15,42 +15,42 @@ export function getServiceAvailableTypes(
   serviceName: string,
   wbFilePath: string,
 ): string[] {
-  let types: string[] = [];
-  let interfaces: string[] = [];
-  let objectTypes: string[] = [];
-  let enums: string[] = [];
-  let scalars: string[] = [];
+  const types: string[] = [];
+  const interfaces: string[] = [];
+  const objectTypes: string[] = [];
+  const enums: string[] = [];
+  const scalars: string[] = [];
 
   try {
-    let localSchema = FileProvider.instance.workbenchFileFromPath(wbFilePath)
+    const localSchema = FileProvider.instance.workbenchFileFromPath(wbFilePath)
       ?.schemas[serviceName];
     if (localSchema) {
-      let doc = parse(localSchema.sdl);
+      const doc = parse(localSchema.sdl);
 
       visit(doc, {
         ObjectTypeDefinition(objectTypeNode: ObjectTypeDefinitionNode) {
-          let typeNode = `O:${objectTypeNode.name.value}`;
+          const typeNode = `O:${objectTypeNode.name.value}`;
           if (!interfaces.includes(typeNode)) {
             interfaces.push(typeNode);
             interfaces.push(`[${typeNode}]`);
           }
         },
         InterfaceTypeDefinition(interfaceNode: InterfaceTypeDefinitionNode) {
-          let typeNode = `I:${interfaceNode.name.value}`;
+          const typeNode = `I:${interfaceNode.name.value}`;
           if (!objectTypes.includes(typeNode)) {
             objectTypes.push(typeNode);
             objectTypes.push(`[${typeNode}]`);
           }
         },
         EnumTypeDefinition(enumNode: EnumTypeDefinitionNode) {
-          let typeNode = `E:${enumNode.name.value}`;
+          const typeNode = `E:${enumNode.name.value}`;
           if (!enums.includes(typeNode)) {
             enums.push(typeNode);
             enums.push(`[${typeNode}]`);
           }
         },
         ScalarTypeDefinition(scalarNode: ScalarTypeDefinitionNode) {
-          let typeNode = `S:${scalarNode.name.value}`;
+          const typeNode = `S:${scalarNode.name.value}`;
           if (!scalars.includes(typeNode)) {
             scalars.push(typeNode);
             scalars.push(`[${typeNode}]`);
@@ -83,15 +83,15 @@ export function getServiceAvailableTypes(
 }
 
 export function extractEntityNames(schema: string): string[] {
-  let entityName: string[] = [];
+  const entityName: string[] = [];
   try {
     runOnlineParser(schema, (state, range, tokens) => {
       switch (state.kind) {
-        case 'StringValue' as any:
-          let argument = state?.prevState?.prevState;
-          let directive = argument?.prevState?.prevState;
-          let objectType = directive?.prevState;
-          let definitionType = objectType?.prevState;
+        case 'StringValue' as any: {
+          const argument = state?.prevState?.prevState;
+          const directive = argument?.prevState?.prevState;
+          const objectType = directive?.prevState;
+          const definitionType = objectType?.prevState;
 
           if (
             objectType?.name &&
@@ -106,6 +106,7 @@ export function extractEntityNames(schema: string): string[] {
               entityName.push(objectType.name);
           }
           break;
+        }
       }
     });
   } catch (err) {

--- a/src/utils/createJavascriptTemplate.ts
+++ b/src/utils/createJavascriptTemplate.ts
@@ -16,15 +16,15 @@ export function createJavascriptTemplate(workbenchFile: ApolloWorkbenchFile) {
   let port = StateManager.settings_startingServerPort;
   const archive = create('zip', { zlib: { level: 9 } });
 
-  const fileName = workbenchFile.graphName.replace(/[\/|\\:*?"<>]/g, ' ');
+  const fileName = workbenchFile.graphName.replace(/[/|\\:*?"<>]/g, ' ');
   archive.append(generateJsVsCodeLaunch('Gateway'), { name: 'launch.json' });
   archive.append(generateJsgatewayPackageJson(), { name: 'package.json' });
   archive.append(generateJsGatewayTempalte(), { name: 'index.js' });
 
-  for (var serviceName in workbenchFile.schemas) {
-    let serviceFolder = `services/${serviceName}`;
-    let serviceVsCodeFolder = `${serviceFolder}/.vscode`;
-    let serviceSrcFolder = `${serviceFolder}/src`;
+  for (const serviceName in workbenchFile.schemas) {
+    const serviceFolder = `services/${serviceName}`;
+    const serviceVsCodeFolder = `${serviceFolder}/.vscode`;
+    const serviceSrcFolder = `${serviceFolder}/src`;
 
     archive.append(generateJsFederatedServerPackageJson(serviceName), {
       name: `${serviceFolder}/package.json`,

--- a/src/utils/createTypescriptTemplate.ts
+++ b/src/utils/createTypescriptTemplate.ts
@@ -17,16 +17,16 @@ export function createTypescriptTemplate(workbenchFile: ApolloWorkbenchFile) {
   let port = StateManager.settings_startingServerPort;
   const archive = create('zip', { zlib: { level: 9 } });
 
-  const fileName = workbenchFile.graphName.replace(/[\/|\\:*?"<>]/g, ' ');
+  const fileName = workbenchFile.graphName.replace(/[/|\\:*?"<>]/g, ' ');
   archive.append(generateTsVsCodeLaunch('Gateway'), { name: 'launch.json' });
   archive.append(generateTsConfig(), { name: 'tsconfig.json' });
   archive.append(generateTsgatewayPackageJson(), { name: 'package.json' });
   archive.append(generateTsGatewayTempalte(), { name: 'index.ts' });
 
-  for (var serviceName in workbenchFile.schemas) {
-    let serviceFolder = `services/${serviceName}`;
-    let serviceVsCodeFolder = `${serviceFolder}/.vscode`;
-    let serviceSrcFolder = `${serviceFolder}/src`;
+  for (const serviceName in workbenchFile.schemas) {
+    const serviceFolder = `services/${serviceName}`;
+    const serviceVsCodeFolder = `${serviceFolder}/.vscode`;
+    const serviceSrcFolder = `${serviceFolder}/src`;
 
     archive.append(generateTsConfig(), {
       name: `${serviceFolder}/tsconfig.json`,

--- a/src/utils/exportFiles.ts
+++ b/src/utils/exportFiles.ts
@@ -20,20 +20,20 @@ export function generateTsConfig() {
 }
 
 export function generateCodeWorkspaceFile(serviceNames: string[]) {
-  let codeWorkspaceFile = {
-    folders: new Array(),
+  const codeWorkspaceFile = {
+    folders: [] as any[],
     launch: {
-      configurations: new Array(),
+      configurations: [] as any[],
       compounds: [
         {
           name: 'Launch All',
-          configurations: new Array(),
+          configurations: [] as any[],
         },
       ],
     },
     tasks: {
       version: '2.0.0',
-      tasks: new Array(),
+      tasks: [] as any[],
     },
   };
 
@@ -51,7 +51,7 @@ export function generateCodeWorkspaceFile(serviceNames: string[]) {
   codeWorkspaceFile.folders.push({ name: `Gateway`, path: `gateway` });
 
   serviceNames.map((serviceName) => {
-    let codeServiceName = `Service - ${serviceName}`;
+    const codeServiceName = `Service - ${serviceName}`;
     codeWorkspaceFile.tasks.tasks[0].dependsOn.push(`setup ${serviceName}`);
     codeWorkspaceFile.tasks.tasks.push({
       label: `setup ${serviceName}`,
@@ -74,7 +74,7 @@ export function generateCodeWorkspaceFile(serviceNames: string[]) {
   return JSON.stringify(codeWorkspaceFile);
 }
 
-let federatedServerPackageJson: any = {
+const federatedServerPackageJson: any = {
   scripts: {
     'local-schema-validation':
       "apollo service:check --variant=$(grep APOLLO_GRAPH_VARIANT .env | cut -d '=' -f2) --serviceName=${serviceName} --localSchemaFile=src/schema.graphql",
@@ -99,7 +99,7 @@ export function generateJsFederatedServerPackageJson(serviceName: string) {
 }
 
 export function generateTsFederatedServerPackageJson(serviceName: string) {
-  let base = federatedServerPackageJson;
+  const base = federatedServerPackageJson;
   base.name = serviceName;
   base.devDependencies = {
     '@types/node': 'latest',
@@ -122,7 +122,7 @@ export function generateTsFederatedServerPackageJson(serviceName: string) {
   return JSON.stringify(base);
 }
 
-let gatewayPackageJson: any = {
+const gatewayPackageJson: any = {
   name: 'graphql-gateway',
   scripts: {
     'list-services':
@@ -145,7 +145,7 @@ export function generateJsgatewayPackageJson() {
 }
 
 export function generateTsgatewayPackageJson() {
-  let base = gatewayPackageJson;
+  const base = gatewayPackageJson;
   base.devDependencies = {
     '@types/node': 'latest',
     '@types/node-fetch': 'latest',
@@ -166,7 +166,7 @@ export function generateTsgatewayPackageJson() {
 
 export function generateJsFederatedResolvers(schema: string) {
   let resolvers = 'const resolvers = {\n';
-  let entities = extractEntityNames(schema);
+  const entities = extractEntityNames(schema);
   entities.forEach(
     (entity) =>
       (resolvers += `\t${entity}: {\n\t\t__resolveReference(parent, args) {\n\t\t\treturn { ...parent }\n\t\t}\n\t}\n`),

--- a/src/workbench/docProviders.ts
+++ b/src/workbench/docProviders.ts
@@ -4,9 +4,9 @@ import path from 'path';
 import { TextDocumentContentProvider, Uri } from 'vscode';
 
 export class GettingStartedDocProvider implements TextDocumentContentProvider {
-  static scheme: string = 'getting-started';
+  static scheme = 'getting-started';
   provideTextDocumentContent(uri: Uri): string {
-    let gettingStartedPath = path.join(
+    const gettingStartedPath = path.join(
       __filename,
       '..',
       '..',
@@ -21,16 +21,16 @@ export class GettingStartedDocProvider implements TextDocumentContentProvider {
 
 export class ApolloStudioOperationsProvider
   implements TextDocumentContentProvider {
-  static scheme: string = 'apollo-studio-operations';
+  static scheme = 'apollo-studio-operations';
   static Uri(operationName: string, document: string): Uri {
     return Uri.parse(
       `${ApolloStudioOperationsProvider.scheme}:${operationName}.graphql?${document}`,
     );
   }
   provideTextDocumentContent(uri: Uri): string {
-    let operationName = uri.path.split('.graphql')[0];
-    let doc = parse(uri.query);
-    let ast = getOperationAST(doc, operationName);
+    const operationName = uri.path.split('.graphql')[0];
+    const doc = parse(uri.query);
+    const ast = getOperationAST(doc, operationName);
     if (ast) return print(ast);
     return uri.query;
   }

--- a/src/workbench/federationCodeActionProvider.ts
+++ b/src/workbench/federationCodeActionProvider.ts
@@ -13,13 +13,13 @@ export class FederationCodeActionProvider implements CodeActionProvider {
     range: Range,
     context: CodeActionContext,
   ): CodeAction[] | undefined {
-    let code = context.diagnostics[0]?.code as string;
-    let selectors: CodeAction[] = [];
+    const code = context.diagnostics[0]?.code as string;
+    const selectors: CodeAction[] = [];
     if (code.includes('makeArray')) {
-      let line = document.lineAt(range.start.line);
-      let trimmedText = line.text.trim();
+      const line = document.lineAt(range.start.line);
+      const trimmedText = line.text.trim();
       if (trimmedText != '[' && trimmedText != '[]' && trimmedText != '[ ]') {
-        let selector = new CodeAction('Make array', CodeActionKind.QuickFix);
+        const selector = new CodeAction('Make array', CodeActionKind.QuickFix);
         selector.command = {
           command: 'current-workbench-schemas.makeSchemaDocTextRangeArray',
           title: 'Make into array',
@@ -30,7 +30,7 @@ export class FederationCodeActionProvider implements CodeActionProvider {
       }
     }
     if (code.includes('deleteRange')) {
-      let selector = new CodeAction(
+      const selector = new CodeAction(
         'Delete this selection',
         CodeActionKind.QuickFix,
       );

--- a/src/workbench/federationCompletionProvider.ts
+++ b/src/workbench/federationCompletionProvider.ts
@@ -27,31 +27,31 @@ export const federationCompletionProvider = {
     token: CancellationToken,
   ) {
     //Only provide completion items for schemas open in workbench
-    let uri = document.uri;
-    let completionItems = new Array<CompletionItem>();
+    const uri = document.uri;
+    const completionItems = new Array<CompletionItem>();
 
     if (uri.scheme == 'workbench' && uri.path.includes('/subgraphs')) {
-      let line = document.lineAt(position.line);
-      let lineText = line.text;
-      let serviceName = document.uri.query;
+      const line = document.lineAt(position.line);
+      const lineText = line.text;
+      const serviceName = document.uri.query;
 
       if (lineText && serviceName) {
         //If not undefined, we're inside a word/something and shouldn't return anything
-        let trimmedText = lineText.trim();
-        let character = trimmedText.charAt(trimmedText.length - 1);
+        const trimmedText = lineText.trim();
+        const character = trimmedText.charAt(trimmedText.length - 1);
         if (character == ':') {
-          let completionTypes = await getServiceAvailableTypes(
+          const completionTypes = await getServiceAvailableTypes(
             serviceName,
             uri.path.split('/subgraphs')[0],
           );
-          for (var i = 0; i < completionTypes.length; i++) {
+          for (let i = 0; i < completionTypes.length; i++) {
             let typeName = completionTypes[i];
             let details = '';
-            let documentation = new MarkdownString();
+            const documentation = new MarkdownString();
             let completionKind = CompletionItemKind.Value;
 
             if (typeName.includes(':')) {
-              let typeSplit = typeName.split(':');
+              const typeSplit = typeName.split(':');
               if (typeSplit[0] == 'I') {
                 details = `Interface ${typeSplit[1]}`;
                 completionKind = CompletionItemKind.Interface;
@@ -85,7 +85,7 @@ export const federationCompletionProvider = {
               );
             }
 
-            let completionItem = new CompletionItem(typeName, completionKind);
+            const completionItem = new CompletionItem(typeName, completionKind);
             completionItem.insertText = typeName;
             completionItem.detail = details;
             completionItem.documentation = documentation;
@@ -95,12 +95,12 @@ export const federationCompletionProvider = {
       } else {
         //Add federation items that can be extended
 
-        let extendableTypes =
+        const extendableTypes =
           StateManager.instance
             .workspaceState_selectedWorkbenchAvailableEntities;
         // await extractDefinedEntitiesByService();
 
-        for (var sn in extendableTypes)
+        for (const sn in extendableTypes)
           if (sn != serviceName)
             extendableTypes[sn].map(({ type, keys }) => {
               Object.keys(keys).forEach((key) => {
@@ -116,10 +116,10 @@ export const federationCompletionProvider = {
         completionItems.push(new EntityObjectTypeCompletionItem());
       }
     } else if (uri.scheme == 'workbench' && uri.path.includes('/queries/')) {
-      let schema = StateManager.instance.workspaceState_schema;
+      const schema = StateManager.instance.workspaceState_schema;
       if (schema) {
-        let query = document.getText();
-        let suggestions = getAutocompleteSuggestions(schema, query, position);
+        const query = document.getText();
+        const suggestions = getAutocompleteSuggestions(schema, query, position);
         if (suggestions.length > 0) {
           suggestions.forEach((ci) =>
             completionItems.push(new QueryCompletionItem(ci)),
@@ -155,8 +155,8 @@ export class EntityObjectTypeCompletionItem extends CompletionItem {
     super('Entity Object type', CompletionItemKind.Snippet);
     this.sortText = 'b';
 
-    let comments = `"""\nThis is an Entity, docs:https://www.apollographql.com/docs/federation/entities/\nYou will need to define a __resolveReference resolver for the type you define, docs: https://www.apollographql.com/docs/federation/entities/#resolving\n"""`;
-    let insertSnippet = new SnippetString(`${comments}\ntype `);
+    const comments = `"""\nThis is an Entity, docs:https://www.apollographql.com/docs/federation/entities/\nYou will need to define a __resolveReference resolver for the type you define, docs: https://www.apollographql.com/docs/federation/entities/#resolving\n"""`;
+    const insertSnippet = new SnippetString(`${comments}\ntype `);
     insertSnippet.appendTabstop(1);
     insertSnippet.appendText(` @key(fields:"id") {\n\tid:ID!\n}`);
 
@@ -173,7 +173,7 @@ export class ObjectTypeCompletionItem extends CompletionItem {
     super('Object type', CompletionItemKind.Snippet);
     this.sortText = 'b';
 
-    let insertSnippet = new SnippetString(
+    const insertSnippet = new SnippetString(
       '"""\nHere are some helpful details about your type\n"""\ntype ',
     );
     insertSnippet.appendTabstop(1);
@@ -192,7 +192,7 @@ export class InterfaceCompletionItem extends CompletionItem {
     super('Interface', CompletionItemKind.Snippet);
     this.sortText = 'b';
 
-    let insertSnippet = new SnippetString('interface ');
+    const insertSnippet = new SnippetString('interface ');
     insertSnippet.appendTabstop(1);
     insertSnippet.appendText(
       ` {\nHere are some helpful details about your interface\n}`,
@@ -216,7 +216,7 @@ export class FederationEntityExtensionItem extends CompletionItem {
     super(`extend ${typeToExtend} by "${key}"`, CompletionItemKind.Reference);
     this.sortText = 'a';
 
-    let insertSnippet = new SnippetString(`extend type `);
+    const insertSnippet = new SnippetString(`extend type `);
     let typeExtensionCodeBlock = `extend type ${typeToExtend} @key(fields:"${key}") {\n`;
 
     insertSnippet.appendVariable('typeToExtend', typeToExtend);
@@ -224,9 +224,9 @@ export class FederationEntityExtensionItem extends CompletionItem {
     insertSnippet.appendVariable('key', key);
     insertSnippet.appendText('") {\n');
 
-    for (var i = 0; i < keyFields.length; i++) {
-      let keyField = keyFields[i];
-      let fieldLine = `\t${keyField.field}: ${keyField.type} @external\n`;
+    for (let i = 0; i < keyFields.length; i++) {
+      const keyField = keyFields[i];
+      const fieldLine = `\t${keyField.field}: ${keyField.type} @external\n`;
       typeExtensionCodeBlock += fieldLine;
       insertSnippet.appendText(fieldLine);
     }
@@ -236,7 +236,7 @@ export class FederationEntityExtensionItem extends CompletionItem {
     typeExtensionCodeBlock += '}';
     insertSnippet.appendText(`\n}`);
 
-    let mkdDocs = new MarkdownString();
+    const mkdDocs = new MarkdownString();
     mkdDocs.appendCodeblock(typeExtensionCodeBlock, 'graphql');
     mkdDocs.appendText(`Owning Service: ${owningServiceName}\n`);
     mkdDocs.appendMarkdown(

--- a/src/workbench/file-system/WorkbenchUri.ts
+++ b/src/workbench/file-system/WorkbenchUri.ts
@@ -19,12 +19,13 @@ export class WorkbenchUri {
     type: WorkbenchUriType = WorkbenchUriType.SUPERGRAPH_SCHEMA,
   ): Uri {
     switch (type) {
-      case WorkbenchUriType.SCHEMAS:
+      case WorkbenchUriType.SCHEMAS: {
         let subgraphPath = resolve(path, 'subgraphs', `${name}.graphql`);
         if (subgraphPath.includes('C:'))
           subgraphPath = subgraphPath.slice(2).replace(/\\/g, '/');
         return Uri.parse(`workbench:${subgraphPath}?${name}`);
-      case WorkbenchUriType.SCHEMAS_SETTINGS:
+      }
+      case WorkbenchUriType.SCHEMAS_SETTINGS: {
         let schemaSettingPath = resolve(
           path,
           'subgraph-settings',
@@ -33,17 +34,20 @@ export class WorkbenchUri {
         if (schemaSettingPath.includes('C:'))
           schemaSettingPath = schemaSettingPath.slice(2).replace(/\\/g, '/');
         return Uri.parse(`workbench:${schemaSettingPath}?${name}`);
-      case WorkbenchUriType.QUERIES:
+      }
+      case WorkbenchUriType.QUERIES: {
         let queryPath = resolve(path, 'queries', `${name}.graphql`);
         if (queryPath.includes('C:'))
           queryPath = queryPath.slice(2).replace(/\\/g, '/');
         return Uri.parse(`workbench:${queryPath}?${name}`);
-      case WorkbenchUriType.QUERY_PLANS:
+      }
+      case WorkbenchUriType.QUERY_PLANS: {
         let queryPlanPath = resolve(path, 'queryplans', `${name}.queryplan`);
         if (queryPlanPath.includes('C:'))
           queryPlanPath = queryPlanPath.slice(2).replace(/\\/g, '/');
         return Uri.parse(`workbench:${queryPlanPath}?${name}`);
-      case WorkbenchUriType.SUPERGRAPH_SCHEMA:
+      }
+      case WorkbenchUriType.SUPERGRAPH_SCHEMA: {
         let superGraphSchemaPath = resolve(
           path,
           'supergraph-schema',
@@ -54,7 +58,8 @@ export class WorkbenchUri {
             .slice(2)
             .replace(/\\/g, '/');
         return Uri.parse(`workbench:${superGraphSchemaPath}?${name}`);
-      case WorkbenchUriType.SUPERGRAPH_API_SCHEMA:
+      }
+      case WorkbenchUriType.SUPERGRAPH_API_SCHEMA: {
         let superGraphApiSchemaPath = resolve(
           path,
           'supergraph-api-schema',
@@ -65,7 +70,8 @@ export class WorkbenchUri {
             .slice(2)
             .replace(/\\/g, '/');
         return Uri.parse(`workbench:${superGraphApiSchemaPath}?${name}`);
-      case WorkbenchUriType.MOCKS:
+      }
+      case WorkbenchUriType.MOCKS: {
         let subgarphMocksPath = resolve(
           StateManager.instance.extensionGlobalStoragePath ?? '',
           'mocks',
@@ -75,6 +81,7 @@ export class WorkbenchUri {
           subgarphMocksPath = subgarphMocksPath.slice(2).replace(/\\/g, '/');
 
         return Uri.parse(`${subgarphMocksPath}?${path}:${name}`);
+      }
     }
   }
 }

--- a/src/workbench/file-system/fileProvider.ts
+++ b/src/workbench/file-system/fileProvider.ts
@@ -33,7 +33,7 @@ export class FileProvider implements FileSystemProvider {
     return this._instance;
   }
 
-  constructor(workspaceRoot?: string) {}
+  constructor(private workspaceRoot?: string) {}
 
   //All workbench files in opened VS Code folder
   private workbenchFiles: Map<string, ApolloWorkbenchFile> = new Map();
@@ -41,10 +41,10 @@ export class FileProvider implements FileSystemProvider {
     this.workbenchFiles.clear();
     const workspaceRoot = StateManager.workspaceRoot;
     if (workspaceRoot) {
-      let workbenchFiles = this.getWorkbenchFilesInDirectory(workspaceRoot);
+      const workbenchFiles = this.getWorkbenchFilesInDirectory(workspaceRoot);
       workbenchFiles.forEach((workbenchFile) => {
         try {
-          let test = JSON.parse(
+          const test = JSON.parse(
             readFileSync(workbenchFile.path, { encoding: 'utf-8' }),
           );
           const wbFile = JSON.parse(
@@ -70,10 +70,7 @@ export class FileProvider implements FileSystemProvider {
 
   loadedWorbenchFilePath = '';
   loadedWorkbenchFile?: ApolloWorkbenchFile;
-  loadWorkbenchForComposition(
-    wbFilePath: string,
-    forceCompose: boolean = false,
-  ) {
+  loadWorkbenchForComposition(wbFilePath: string, forceCompose = false) {
     if (this.loadedWorbenchFilePath != wbFilePath) {
       this.loadedWorbenchFilePath = wbFilePath;
       this.loadedWorkbenchFile = this.workbenchFileFromPath(wbFilePath);
@@ -90,8 +87,8 @@ export class FileProvider implements FileSystemProvider {
   }
 
   async promptOpenFolder() {
-    let openFolder = 'Open Folder';
-    let response = await window.showErrorMessage(
+    const openFolder = 'Open Folder';
+    const response = await window.showErrorMessage(
       'You must open a folder to create Apollo Workbench files',
       openFolder,
     );
@@ -133,7 +130,7 @@ export class FileProvider implements FileSystemProvider {
   saveWorkbenchFile(
     wbFile: ApolloWorkbenchFile,
     wbFilePath: string,
-    refreshTree: boolean = true,
+    refreshTree = true,
   ) {
     writeFileSync(wbFilePath, JSON.stringify(wbFile), { encoding: 'utf8' });
     if (refreshTree)
@@ -199,7 +196,7 @@ export class FileProvider implements FileSystemProvider {
       const wbFile = this.workbenchFileFromPath(wbFilePath);
       const subgraph = wbFile?.schemas[name];
       if (subgraph) {
-        let settings: WorkbenchSettings = {
+        const settings: WorkbenchSettings = {
           url: subgraph?.url ?? '',
           requiredHeaders: subgraph?.requiredHeaders ?? [],
           mocks: {
@@ -361,7 +358,7 @@ export class FileProvider implements FileSystemProvider {
     uri: Uri,
     options: { recursive: boolean; excludes: string[] },
   ): Disposable {
-    return new Disposable(() => {});
+    return new Disposable(() => undefined);
   }
   stat(uri: Uri): FileStat | Thenable<FileStat> {
     const now = Date.now();
@@ -386,12 +383,12 @@ export class FileProvider implements FileSystemProvider {
   private getWorkbenchFilesInDirectory(dirPath: string) {
     if (!dirPath || dirPath == '.') return [];
 
-    let workbenchFiles = new Array<Uri>();
-    let directories = new Array<string>();
+    const workbenchFiles = new Array<Uri>();
+    const directories = new Array<string>();
     directories.push(dirPath);
 
     while (directories.length > 0) {
-      let directory = directories[0];
+      const directory = directories[0];
       const dirents = readdirSync(directory, { withFileTypes: true });
       for (const dirent of dirents) {
         const directoryPath = path.resolve(directory, dirent.name);
@@ -410,8 +407,8 @@ export class FileProvider implements FileSystemProvider {
   }
 
   getPreloadedWorkbenchFiles() {
-    let items: { fileName: string; path: string }[] = [];
-    let preloadFileDir = join(
+    const items: { fileName: string; path: string }[] = [];
+    const preloadFileDir = join(
       __dirname,
       '..',
       '..',
@@ -420,7 +417,7 @@ export class FileProvider implements FileSystemProvider {
       `preloaded-files`,
     );
     if (existsSync(preloadFileDir)) {
-      let preloadedDirectory = readdirSync(preloadFileDir, {
+      const preloadedDirectory = readdirSync(preloadFileDir, {
         encoding: 'utf-8',
       });
       preloadedDirectory.map((item) => {

--- a/src/workbench/file-system/fileTypes.ts
+++ b/src/workbench/file-system/fileTypes.ts
@@ -17,14 +17,14 @@ export class ApolloWorkbenchFile {
   operations: { [opName: string]: string } = {};
   queryPlans: { [opName: string]: string } = {};
   schemas: { [serviceName: string]: WorkbenchSchema } = {};
-  supergraphSdl: string = '';
+  supergraphSdl = '';
 
   constructor(public graphName: string) {}
 }
 
 ///This is the user facing settings displayed
 export class WorkbenchSettings {
-  url: string = '';
+  url = '';
   requiredHeaders?: [RequiredHeader?];
   mocks: {
     shouldMock: boolean;

--- a/src/workbench/serverManager.ts
+++ b/src/workbench/serverManager.ts
@@ -23,6 +23,7 @@ import { execSync } from 'child_process';
 import { Disposable } from 'vscode-languageclient';
 import { WorkbenchUri, WorkbenchUriType } from './file-system/WorkbenchUri';
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const { name } = require('../../package.json');
 
 export class ServerManager {
@@ -48,11 +49,13 @@ export class ServerManager {
     else process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
     console.log(`${name}:Setting up mocks`);
-    let workbenchFile = FileProvider.instance.workbenchFileFromPath(wbFilePath);
+    const workbenchFile = FileProvider.instance.workbenchFileFromPath(
+      wbFilePath,
+    );
     if (workbenchFile) {
       console.log(`${name}:Mocking workbench file: ${workbenchFile.graphName}`);
       FileProvider.instance.loadedWorkbenchFile = workbenchFile;
-      for (var serviceName in workbenchFile.schemas) {
+      for (const serviceName in workbenchFile.schemas) {
         //Check if we should be mocking this service
         if (workbenchFile.schemas[serviceName].shouldMock) {
           //Check if Custom Mocks are defined in workbench
@@ -63,7 +66,7 @@ export class ServerManager {
               customMocks = customMocks.concat('\nmodule.exports = mocks');
 
             try {
-              let mocks = eval(customMocks);
+              const mocks = eval(customMocks);
               this.startServer(
                 serviceName,
                 workbenchFile.schemas[serviceName].sdl,
@@ -92,7 +95,7 @@ export class ServerManager {
     if (this.serversState?.gateway)
       this.serversState.gateway.experimental_pollInterval = 10000000;
 
-    for (var port in this.serversState) {
+    for (const port in this.serversState) {
       if (port != 'gateway') {
         console.log(`${name}:Stopping server running at port ${port}...`);
         this.stopServerOnPort(port);
@@ -141,8 +144,8 @@ export class ServerManager {
       }
 
       //Dynamically create __resolveReference resolvers based on defined entites in Graph
-      let resolvers = {};
-      let entities = extractEntityNames(schemaString);
+      const resolvers = {};
+      const entities = extractEntityNames(schemaString);
       entities.forEach(
         (entity) =>
           (resolvers[entity] = {
@@ -189,7 +192,7 @@ export class ServerManager {
   }
   private stopServerOnPort(port: string) {
     let serviceName = '';
-    for (var sn in this.portMapping)
+    for (const sn in this.portMapping)
       if (this.portMapping[sn] == port) serviceName = sn;
 
     this.stopServer(port);
@@ -198,7 +201,7 @@ export class ServerManager {
   }
   statusBarMessage: Disposable = window.setStatusBarMessage('');
   private stopGateway() {
-    let gatewayPort = StateManager.settings_gatewayServerPort;
+    const gatewayPort = StateManager.settings_gatewayServerPort;
     if (this.serversState[gatewayPort]) {
       console.log(`${name}:Stopping previous running gateway`);
       this.serversState[gatewayPort].stop();
@@ -207,7 +210,7 @@ export class ServerManager {
     if (this.statusBarMessage) this.statusBarMessage.dispose();
   }
   private startGateway() {
-    let gatewayPort = StateManager.settings_gatewayServerPort;
+    const gatewayPort = StateManager.settings_gatewayServerPort;
     if (this.serversState[gatewayPort]) {
       console.log(`${name}:Stopping previous running gateway`);
       this.serversState[gatewayPort].stop();
@@ -228,7 +231,7 @@ export class ServerManager {
       gateway: new OverrideApolloGateway({
         debug: true,
         buildService({ url, name }) {
-          let source = new GatewayForwardHeadersDataSource({ url });
+          const source = new GatewayForwardHeadersDataSource({ url });
           source.serviceName = name;
           return source;
         },

--- a/src/workbench/tree-data-providers/apolloStudioGraphOpsTreeDataProvider.ts
+++ b/src/workbench/tree-data-providers/apolloStudioGraphOpsTreeDataProvider.ts
@@ -23,21 +23,21 @@ export class ApolloStudioGraphOpsTreeDataProvider
     if (element) return element.versions ?? element.operations;
 
     let noOperationsFoundMessage = '';
-    let items: {
+    const items: {
       [operationName: string]: {
         operationId: string;
         operationSignature: string;
       };
     } = {};
-    let apiKey = StateManager.instance.globalState_userApiKey;
+    const apiKey = StateManager.instance.globalState_userApiKey;
     if (!apiKey) return [new NotLoggedInTreeItem()];
 
-    let selectedGraphId = StateManager.instance.globalState_selectedGraph;
-    let graphVariant = StateManager.instance.globalState_selectedGraphVariant;
+    const selectedGraphId = StateManager.instance.globalState_selectedGraph;
+    const graphVariant = StateManager.instance.globalState_selectedGraphVariant;
     if (selectedGraphId) {
       //Create objects for next for loop
       //  Return A specific account with all graphs
-      let graphOps = await getGraphOps(apiKey, selectedGraphId, graphVariant);
+      const graphOps = await getGraphOps(apiKey, selectedGraphId, graphVariant);
 
       noOperationsFoundMessage = graphVariant
         ? `No operations found for ${graphOps.service?.title}@${graphVariant}`
@@ -64,10 +64,10 @@ export class ApolloStudioGraphOpsTreeDataProvider
         ),
       ];
 
-    let itemsToReturn: vscode.TreeItem[] = new Array<vscode.TreeItem>();
+    const itemsToReturn: vscode.TreeItem[] = new Array<vscode.TreeItem>();
 
-    for (var operationName in items) {
-      let op = items[operationName];
+    for (const operationName in items) {
+      const op = items[operationName];
       itemsToReturn.push(
         new StudioOperationTreeItem(
           op.operationId,

--- a/src/workbench/tree-data-providers/apolloStudioGraphsTreeDataProvider.ts
+++ b/src/workbench/tree-data-providers/apolloStudioGraphsTreeDataProvider.ts
@@ -35,16 +35,16 @@ export class ApolloStudioGraphsTreeDataProvider
 
   async getChildren(element?: StudioAccountTreeItem): Promise<TreeItem[]> {
     if (element) return element.children;
-    let items: TreeItem[] = new Array<TreeItem>();
+    const items: TreeItem[] = new Array<TreeItem>();
 
-    let apiKey = StateManager.instance.globalState_userApiKey;
+    const apiKey = StateManager.instance.globalState_userApiKey;
     if (apiKey) {
       let accountId = StateManager.instance.globalState_selectedApolloAccount;
       if (!accountId) {
         const myAccountIds = await getUserMemberships(apiKey);
         const memberships = (myAccountIds?.me as any)?.memberships;
         if (memberships?.length > 1) {
-          let accountIds: string[] = new Array<string>();
+          const accountIds: string[] = new Array<string>();
           memberships.map((membership) =>
             accountIds.push(membership.account.id),
           );
@@ -63,33 +63,36 @@ export class ApolloStudioGraphsTreeDataProvider
 
         //Create objects for next for loop
         //  Return A specific account with all graphs
-        let services = await getAccountGraphs(apiKey, accountId);
-        let accountTreeItem = new StudioAccountTreeItem(
+        const services = await getAccountGraphs(apiKey, accountId);
+        const accountTreeItem = new StudioAccountTreeItem(
           accountId,
           services?.account?.name,
         );
 
         if (services?.account?.services) {
-          let accountServiceTreeItems = new Array<StudioGraphTreeItem>();
+          const accountServiceTreeItems = new Array<StudioGraphTreeItem>();
 
-          for (var j = 0; j < services?.account?.services.length ?? 0; j++) {
+          for (let j = 0; j < services?.account?.services.length ?? 0; j++) {
             //Cast graph
-            let graph = services?.account?.services[j];
+            const graph = services?.account?.services[j];
             if (graph.devGraphOwner?.id) {
               continue;
             }
             //Create objects for next for loop
             //  Return A specific Graph with all variants
-            let graphTreeItem = new StudioGraphTreeItem(graph.id, graph.title);
-            let graphVariantTreeItems = new Array<StudioGraphVariantTreeItem>();
+            const graphTreeItem = new StudioGraphTreeItem(
+              graph.id,
+              graph.title,
+            );
+            const graphVariantTreeItems = new Array<StudioGraphVariantTreeItem>();
 
             //Loop through graph variants and add to return objects
-            for (var k = 0; k < graph.variants.length; k++) {
+            for (let k = 0; k < graph.variants.length; k++) {
               //Cast graph variant
-              let graphVariant = graph.variants[k];
+              const graphVariant = graph.variants[k];
               graphTreeItem.variants.push(graphVariant.name);
 
-              let accountgraphVariantTreeItem = new StudioGraphVariantTreeItem(
+              const accountgraphVariantTreeItem = new StudioGraphVariantTreeItem(
                 graph.id,
                 graphVariant.name,
               );
@@ -128,7 +131,7 @@ export class ApolloStudioGraphsTreeDataProvider
 }
 
 export class NotLoggedInTreeItem extends TreeItem {
-  constructor(message: string = 'Click here to login with your user api key') {
+  constructor(message = 'Click here to login with your user api key') {
     super(message, TreeItemCollapsibleState.None);
     this.command = {
       title: 'Login to Apollo',
@@ -229,7 +232,7 @@ export class PreloadedWorkbenchTopLevel extends TreeItem {
   constructor() {
     super('Example Graphs', TreeItemCollapsibleState.Collapsed);
 
-    let preloadedFiles = FileProvider.instance?.getPreloadedWorkbenchFiles();
+    const preloadedFiles = FileProvider.instance?.getPreloadedWorkbenchFiles();
     preloadedFiles.map((preloadedFile) => {
       this.children.push(new PreloadedWorkbenchFile(preloadedFile.fileName));
     });

--- a/src/workbench/tree-data-providers/superGraphTreeDataProvider.ts
+++ b/src/workbench/tree-data-providers/superGraphTreeDataProvider.ts
@@ -16,8 +16,6 @@ import { StateManager } from '../stateManager';
 
 export class LocalSupergraphTreeDataProvider
   implements TreeDataProvider<TreeItem> {
-  constructor() {}
-
   private _onDidChangeTreeData: EventEmitter<undefined> = new EventEmitter<undefined>();
   readonly onDidChangeTreeData: Event<undefined> = this._onDidChangeTreeData
     .event;
@@ -32,7 +30,7 @@ export class LocalSupergraphTreeDataProvider
 
   getChildren(element?: TreeItem): Thenable<TreeItem[]> {
     if (element == undefined) {
-      let items = new Array<TreeItem>();
+      const items = new Array<TreeItem>();
       const workbenchFiles = FileProvider.instance.refreshLocalWorkbenchFiles();
       workbenchFiles.forEach((wbFile, wbFilePath) => {
         items.push(new SupergraphTreeItem(wbFile, wbFilePath));
@@ -52,9 +50,9 @@ export class LocalSupergraphTreeDataProvider
       return Promise.resolve(items);
     } else {
       switch (element.contextValue) {
-        case 'supergraphTreeItem':
+        case 'supergraphTreeItem': {
           const supergraphItem = element as SupergraphTreeItem;
-          let subgraphItem = element as SupergraphTreeItem;
+          const subgraphItem = element as SupergraphTreeItem;
 
           //Support legacy composition in workbench files
           if (
@@ -79,7 +77,7 @@ export class LocalSupergraphTreeDataProvider
               supergraphItem.operationsChild,
             ]);
           } else {
-            let invalidCompositionItem = new TreeItem(
+            const invalidCompositionItem = new TreeItem(
               'INVALID COMPOSITION',
               TreeItemCollapsibleState.None,
             );
@@ -92,6 +90,7 @@ export class LocalSupergraphTreeDataProvider
               subgraphItem.operationsChild,
             ]);
           }
+        }
         case 'subgraphSummaryTreeItem':
           return Promise.resolve(
             (element as SubgraphSummaryTreeItem).subgraphs,


### PR DESCRIPTION
@typescript-eslint/no-array-constructor -- switched to `[] as any[]`
@typescript-eslint/no-empty-function -- switched to `() => undefined`
@typescript-eslint/no-inferrable-types -- removed
@typescript-eslint/no-var-requires <== ignored
no-async-promise-executor -- rewrote to use .then
no-case-declarations -- added `{}` around case blocks
no-fallthrough -- added return/break before `default:`
no-useless-escape -- removed
no-var -- converted to const
prefer-const -- most common; autocorrected to const