### PR TITLE
3.2.12 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Apollo Workbench VSCode 3.2.12
 
 - Enable setting Router Version in VSCode settings
+- Better support `subgraph_url` to load read-only schema
 
 ## Apollo Workbench VSCode 3.2.11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - Enable setting Router Version in VSCode settings
 - Better support `subgraph_url` to load read-only schema
+- Create `subgraph_url` watcher to ping changes
+  - Introduce settings `enableSubgraphUrlWatcher` and `subgraphWatcherPingInterval` to allow a user to disable/enable the watcher and set the interval the watcher pings `subgraph_url` for updates.
+  - Any updates in the watcher will trigger refreshing composition for that design file
 
 ## Apollo Workbench VSCode 3.2.11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Apollo Workbench VSCode 3.2.12
+
+- Enable setting Router Version in VSCode settings
+
 ## Apollo Workbench VSCode 3.2.11
 
 - Fix [#168](https://github.com/apollographql/apollo-workbench-vscode/issues/168) - fix "openFolder" command. It needed to include "vscode.openFolder".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Apollo Workbench VSCode 3.2.12
 
-- Enable setting Router Version in VSCode settings
+- Enable setting Router Version in VSCode settings `routerVersion`
 - Better support `subgraph_url` to load read-only schema
 - Create `subgraph_url` watcher to ping changes
   - Introduce settings `enableSubgraphUrlWatcher` and `subgraphWatcherPingInterval` to allow a user to disable/enable the watcher and set the interval the watcher pings `subgraph_url` for updates.

--- a/package.json
+++ b/package.json
@@ -108,6 +108,12 @@
           "default": true,
           "description": "Determines whether https://studio.apollographql.com/sandbox should be opened when mocks are started for a workbench design"
         },
+        "apollo-workbench.routerVersion": {
+          "type": [
+            "string"
+          ],
+          "description": "Specifies the version of Apollo Router should be used with `rover dev`. Defautls to latest."
+        },
         "apollo-workbench.routerPort": {
           "type": [
             "number"

--- a/package.json
+++ b/package.json
@@ -141,6 +141,20 @@
           "default": 4001,
           "description": "Specifies the url endpoint to be used for the Apollo Studio Graph"
         },
+        "apollo-workbench.enableSubgraphUrlWatcher": {
+          "type": [
+            "boolean"
+          ],
+          "default": true,
+          "description": "Runs a watcher in the background to fetch updates from subgraph_url's defined in designs"
+        },
+        "apollo-workbench.subgraphWatcherPingInterval": {
+          "type": [
+            "number"
+          ],
+          "default": 1000,
+          "description": "Determines the interval of pings `rover subgraph introspect` shoud be called by the watcher"
+        },
         "apollo-workbench.daysOfOperationsToFetch": {
           "type": [
             "number"

--- a/src/commands/local-supergraph-designs.ts
+++ b/src/commands/local-supergraph-designs.ts
@@ -32,6 +32,7 @@ import { viewOperationDesign } from '../workbench/webviews/operationDesign';
 import {
   ApolloRemoteSchemaProvider,
   DesignOperationsDocumentProvider,
+  SubgraphUrlSchemaProvider,
 } from '../workbench/docProviders';
 import { openFolder } from './extension';
 import { whichDesign, whichOperation, whichSubgraph } from '../utils/uiHelpers';
@@ -278,6 +279,13 @@ export async function editSubgraph(item?: SubgraphTreeItem) {
     } else if (subgraphSchemaConfig.workbench_design) {
       await window.showTextDocument(
         resolvePath(subgraphSchemaConfig.workbench_design),
+      );
+    } else if (subgraphSchemaConfig.subgraph_url) {
+      await window.showTextDocument(
+        SubgraphUrlSchemaProvider.Uri(
+          subgraphName,
+          subgraphSchemaConfig.subgraph_url,
+        ),
       );
     } else {
       const tempLocation = ApolloRemoteSchemaProvider.Uri(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -64,6 +64,7 @@ import { openSandbox, refreshSandbox } from './workbench/webviews/sandbox';
 import { FederationReferenceProvider } from './workbench/federationReferenceProvider';
 import { viewPreloadedSchema } from './commands/preloaded';
 import { log } from './utils/logger';
+import { SubgraphWatcher } from './utils/subgraphWatcher';
 
 export const outputChannel = window.createOutputChannel('Apollo Workbench');
 
@@ -285,6 +286,9 @@ export async function activate(context: ExtensionContext) {
       isCaseSensitive: true,
     },
   );
+
+  SubgraphWatcher.instance.start();
+
   workspace.onDidDeleteFiles((e) => {
     let deletedWorkbenchFile = false;
     e.files.forEach((f) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,7 @@ import {
   ApolloStudioOperationsProvider,
   DesignOperationsDocumentProvider,
   PreloadedSchemaProvider,
+  SubgraphUrlSchemaProvider,
 } from './workbench/docProviders';
 import { addToDesign } from './commands/studio-operations';
 import {
@@ -259,6 +260,10 @@ export async function activate(context: ExtensionContext) {
   workspace.registerTextDocumentContentProvider(
     ApolloStudioOperationsProvider.scheme,
     new ApolloStudioOperationsProvider(),
+  );
+  workspace.registerTextDocumentContentProvider(
+    SubgraphUrlSchemaProvider.scheme,
+    new SubgraphUrlSchemaProvider(),
   );
   workspace.registerTextDocumentContentProvider(
     ApolloRemoteSchemaProvider.scheme,

--- a/src/utils/subgraphWatcher.ts
+++ b/src/utils/subgraphWatcher.ts
@@ -1,0 +1,80 @@
+import { Uri, workspace } from 'vscode';
+import { FileProvider } from '../workbench/file-system/fileProvider';
+import { Rover } from '../workbench/rover';
+import { log } from './logger';
+import { StateManager } from '../workbench/stateManager';
+
+export interface Watcher {
+  wbFilePath: string;
+  subgraphName: string;
+  url: string;
+}
+
+export class SubgraphWatcher {
+  private watchers: Array<Watcher> = [];
+
+  private _isRunning = false;
+
+  static instance = new SubgraphWatcher();
+
+  refresh() {
+    this.watchers = [];
+    const wbFiles = FileProvider.instance.getWorkbenchFiles();
+    wbFiles.forEach((wbFile, wbFilePath) => {
+      Object.keys(wbFile.subgraphs).forEach((subgraphName) => {
+        const subgraph = wbFile.subgraphs[subgraphName];
+        if (subgraph.schema.subgraph_url != undefined) {
+          this.watchers.push({
+            wbFilePath,
+            subgraphName,
+            url: subgraph.schema.subgraph_url,
+          });
+        }
+      });
+    });
+
+    this.start();
+  }
+
+  start() {
+    if (this._isRunning) return;
+    this._isRunning = true;
+    this.watch();
+  }
+  stop() {
+    this._isRunning = false;
+  }
+
+  private async watch() {
+    while (this._isRunning && StateManager.settings_enableSubgraphUrlWatcher) {
+      const loopStart = Date.now();
+      for (let i = 0; i < this.watchers.length; i++) {
+        const watcher = this.watchers[i];
+        const didUpdate =
+          await FileProvider.instance.updateTempSubgraphUrlSchema(
+            watcher.wbFilePath,
+            watcher.subgraphName,
+            watcher.url,
+          );
+
+        if (didUpdate) {
+          log(
+            `Found update for ${watcher.subgraphName} running at ${watcher.url}`,
+          );
+          await FileProvider.instance.refreshWorkbenchFileComposition(
+            watcher.wbFilePath,
+          );
+        }
+      }
+      const loopTimeElapsed = Date.now() - loopStart;
+      if (loopTimeElapsed < StateManager.settings_subgraphWatcherPingInterval) {
+        await sleep(
+          StateManager.settings_subgraphWatcherPingInterval - loopTimeElapsed,
+        );
+      }
+    }
+
+    this._isRunning = false;
+  }
+}
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));

--- a/src/workbench/docProviders.ts
+++ b/src/workbench/docProviders.ts
@@ -16,6 +16,8 @@ import {
 } from 'vscode';
 import { FileProvider } from './file-system/fileProvider';
 import { normalizePath } from '../utils/path';
+import { Subgraph } from './file-system/ApolloConfig';
+import { Rover } from '../../out/workbench/rover';
 
 export class DesignOperationsDocumentProvider implements FileSystemProvider {
   static scheme = 'workbench';
@@ -129,6 +131,19 @@ export class ApolloStudioOperationsProvider
     const ast = getOperationAST(doc, operationName);
     if (ast) return print(ast);
     return uri.query;
+  }
+}
+
+export class SubgraphUrlSchemaProvider implements TextDocumentContentProvider {
+  static scheme = 'apollo-workbench-subgraph-url';
+  static Uri(subgraphName: string, url: string): Uri {
+    return Uri.parse(
+      `${SubgraphUrlSchemaProvider.scheme}:${subgraphName}.graphql?${url}`,
+    );
+  }
+
+  async provideTextDocumentContent(uri: Uri): Promise<string> {
+    return await Rover.instance.subgraphIntrospect(uri.query);
   }
 }
 

--- a/src/workbench/rover.ts
+++ b/src/workbench/rover.ts
@@ -47,7 +47,7 @@ export class Rover {
   runningFilePath: string | undefined;
   primaryDevTerminal: Terminal | undefined;
 
-  private async execute(command: string, json = true) {
+  private async execute(command: string, json = true, shouldLog = true) {
     let cmd = json ? `${command} --format=json` : command;
     if (StateManager.settings_roverConfigProfile) {
       cmd = `${cmd} --profile=${StateManager.settings_roverConfigProfile}`;
@@ -60,7 +60,7 @@ export class Rover {
     //     cmd = `APOLLO_KEY=${StateManager.instance.globalState_userApiKey} ${cmd}`;
     // }
 
-    this.logCommand(cmd);
+    if (shouldLog) this.logCommand(cmd);
 
     if (process.platform !== 'win32') {
       //workaround, source rover binary from install location
@@ -222,9 +222,13 @@ export class Rover {
     return result ? result : '';
   }
   async subgraphIntrospect(url: string) {
-    let sdl = await this.execute(`rover subgraph introspect ${url}`, false);
+    let sdl = await this.execute(
+      `rover subgraph introspect ${url}`,
+      false,
+      false,
+    );
     if (!sdl ?? sdl == '') {
-      sdl = await this.execute(`rover graph introspect ${url}`, false);
+      sdl = await this.execute(`rover graph introspect ${url}`, false, false);
     }
     return sdl ? sdl : '';
   }

--- a/src/workbench/rover.ts
+++ b/src/workbench/rover.ts
@@ -489,7 +489,10 @@ export class Rover {
       : normalizePath(
           resolve(__dirname, '..', 'media', `preloaded-files`, 'router.yaml'),
         );
-    const command = `rover dev --supergraph-config=${config} --supergraph-port=${StateManager.settings_routerPort} --router-config=${configPath}`;
+    let command = `rover dev --supergraph-config=${config} --supergraph-port=${StateManager.settings_routerPort} --router-config=${configPath}`;
+    if (StateManager.settings_routerVersion) {
+      command = `APOLLO_ROVER_DEV_ROUTER_VERSION=${StateManager.settings_routerVersion} ${command}`;
+    }
     this.primaryDevTerminal = window.createTerminal(wbFilePath);
     this.primaryDevTerminal.show();
     this.primaryDevTerminal.sendText(command);

--- a/src/workbench/stateManager.ts
+++ b/src/workbench/stateManager.ts
@@ -59,6 +59,11 @@ export class StateManager {
         ?.get('openSandboxOnStartMocks') ?? true
     );
   }
+  static get settings_routerVersion(): string | undefined {
+    return workspace
+      ?.getConfiguration('apollo-workbench')
+      ?.get('routerVersion');
+  }
   static get settings_routerPort(): number {
     return (
       workspace?.getConfiguration('apollo-workbench')?.get('routerPort') ??

--- a/src/workbench/stateManager.ts
+++ b/src/workbench/stateManager.ts
@@ -77,6 +77,20 @@ export class StateManager {
         ?.get('routerConfigFile') ?? ''
     );
   }
+  static get settings_enableSubgraphUrlWatcher(): boolean {
+    return (
+      workspace
+        ?.getConfiguration('apollo-workbench')
+        ?.get('enableSubgraphUrlWatcher') ?? true
+    );
+  }
+  static get settings_subgraphWatcherPingInterval(): number {
+    return (
+      workspace
+        ?.getConfiguration('apollo-workbench')
+        ?.get('subgraphWatcherPingInterval') ?? 1000
+    );
+  }
   static get settings_apiKey() {
     return (
       (workspace


### PR DESCRIPTION
- Enable setting Router Version in VSCode settings `routerVersion`
- Better support `subgraph_url` to load read-only schema
- Create `subgraph_url` watcher to ping changes
  - Introduce settings `enableSubgraphUrlWatcher` and `subgraphWatcherPingInterval` to allow a user to disable/enable the watcher and set the interval the watcher pings `subgraph_url` for updates.
  - Any updates in the watcher will trigger refreshing composition for that design file