### PR TITLE
fixing yaml parsing errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ You can stop the design at anytime by pressing the "Stop" icon when hovering ove
 
 ### Mocking designs locally
 
-By default, designs running locally will route traffice to the `routing_url` defined in the `yaml`. If you want to mock any schema, you can right click that schema and select "Mock Subgraph in Design":
+By default, designs running locally will route traffic to the `routing_url` defined in the `yaml`. If you want to mock any schema, you can right click that schema and select "Mock Subgraph in Design":
 
 ![](images/mock-subgraph.png)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "apollo-workbench",
-      "version": "3.2.8",
+      "version": "3.2.13",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {

--- a/src/workbench/file-system/fileProvider.ts
+++ b/src/workbench/file-system/fileProvider.ts
@@ -514,10 +514,15 @@ export class FileProvider {
           const yamlFile = await workspace.fs.readFile(
             Uri.parse(directoryPath),
           );
-          const yaml = load(new TextDecoder().decode(yamlFile)) as ApolloConfig;
-          if (yaml?.federation_version) {
-            workbenchFiles.push(Uri.parse(directoryPath));
+          try {
+            const yaml = load(new TextDecoder().decode(yamlFile)) as ApolloConfig;
+            if (yaml?.federation_version) {
+              workbenchFiles.push(Uri.parse(directoryPath));
+            }
+          } catch (error) {
+            console.log(`Error parsing ${directoryPath}\nError: ${error}`);
           }
+
         }
       }
 

--- a/src/workbench/tree-data-providers/tree-items/graphos-supergraphs/preloadedWorkbenchFile.ts
+++ b/src/workbench/tree-data-providers/tree-items/graphos-supergraphs/preloadedWorkbenchFile.ts
@@ -18,6 +18,9 @@ export class PreloadedWorkbenchFile extends TreeItem {
     const wbFile = await FileProvider.instance.getPreloadedWorkbenchFile(
       this.filePath,
     );
+    if (!wbFile || !wbFile.subgraphs) {
+      return [];
+    }
     Object.keys(wbFile.subgraphs).forEach((s) =>
       this.children.push(
         new PreloadedSubgraph(s, this.fileName, this.filePath),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "noImplicitAny": false,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "allowJs": true
+    "allowJs": false
   },
   "exclude": ["node_modules"],
   "lib": ["dom"]


### PR DESCRIPTION
Fixes: 

* Case where Helm chart `*.yaml` files cause the load to fail 
* Insignificant parsing issue for the preloaded files

