### PR TITLE
Fix `rover dev` for dynamic urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Apollo Workbench VSCode 3.3.9
+
+- Create `graphRef` setting - when using the play button to start a design locally, `rover dev` needs to pass a graph ref to an enterprise graph in GraphOS. This setting enables a user to set the name of their graph for the extension to work with.  
+
+## Apollo Workbench VSCode 3.3.8
+
+- Introduced auto upload to VS Code marketplace.
+
 ## Apollo Workbench VSCode 3.3.6
 
 - Fix taken ports for subgraphs by setting `port: 0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Apollo Workbench VSCode 3.3.9
 
-- Create `graphRef` setting - when using the play button to start a design locally, `rover dev` needs to pass a graph ref to an enterprise graph in GraphOS. This setting enables a user to set the name of their graph for the extension to work with.  
+- Create `graphRef` setting - when using the play button to start a design locally, `rover dev` needs to pass a graph ref to an enterprise graph in GraphOS. This setting enables a user to set the name of their graph for the extension to work with.
+- Fix subgraph mock reload - dynamic urls introduced in `3.3.6` ended up breaking mocks because the supergraph composition was configured for the old ports. Rather than manage the router config, we simply store the subgraph port start so that it is dynamically created only on start. The created port is then re-used for all restarts of the subgraph mocks.  
 
 ## Apollo Workbench VSCode 3.3.8
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ subgraphs:
       graphref: hack-the-e-commerce@main
       subgraph: orders
 operations: {}
-federation_version: '=2.5.2'
+federation_version: '=2.7.2'
 ```
 
 ### Creating a design from scratch

--- a/media/preloaded-files/Retail-Supergraph.yaml
+++ b/media/preloaded-files/Retail-Supergraph.yaml
@@ -1,4 +1,4 @@
-federation_version: '=2.5.2'
+federation_version: '=2.7.2'
 subgraphs:
   users:
     routing_url: https://apollosolutions--retail-supergraph.fly.dev/users/graphql

--- a/media/preloaded-files/Spotify-Showcase.yaml
+++ b/media/preloaded-files/Spotify-Showcase.yaml
@@ -1,4 +1,4 @@
-federation_version: '=2.5.2'
+federation_version: '=2.7.2'
 subgraphs:
   spotify:
     routing_url: https://showcase-spotify.apollographql.com/

--- a/media/preloaded-files/router.yaml
+++ b/media/preloaded-files/router.yaml
@@ -14,3 +14,7 @@ headers:
     request:
       - propagate:
           matching: .*
+telemetry:
+  instrumentation:
+    spans:
+      mode: spec_compliant

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@apollo/client": "^3.4.16",
         "@apollo/server": "^4.8.1",
-        "@apollo/subgraph": "^2.4.3",
+        "@apollo/subgraph": "^2.7.2",
         "@faker-js/faker": "^8.2.0",
         "@graphql-tools/mock": "^8.7.14",
         "@graphql-typed-document-node/core": "^3.2.0",
@@ -128,9 +128,9 @@
       }
     },
     "node_modules/@apollo/federation-internals": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@apollo/federation-internals/-/federation-internals-2.5.1.tgz",
-      "integrity": "sha512-+TSt+GJWBeDiHRsLhaake2sYDni2yW3f4xRSq3+I6vsHs1GIcKgUbhq4fiDe61v6OXU1IckuI+TELRSMZNNh6A==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@apollo/federation-internals/-/federation-internals-2.7.2.tgz",
+      "integrity": "sha512-i+9mbw8UN6P+i5xpLxH3m8n3zqEBzoN8a1cct4yrab9loiZeIlxW8cLXzqglEMic++Sz9tai4L21ZY0GlW8ebg==",
       "dependencies": {
         "@types/uuid": "^9.0.0",
         "chalk": "^4.1.0",
@@ -222,12 +222,12 @@
       }
     },
     "node_modules/@apollo/subgraph": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@apollo/subgraph/-/subgraph-2.5.1.tgz",
-      "integrity": "sha512-q6L9pbGL+R9yZpX4sQlf9YPwe/skbQB2pgOLV+H0m83nEwAx0eKgjuzNGqokb9YBYU23dv3kkItR3nHBw5RMUw==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@apollo/subgraph/-/subgraph-2.7.2.tgz",
+      "integrity": "sha512-n3N8HULcj0Mpegsgd9z4MK2oEbC4BVJFuhcrliNdpq+vlcmvOaEaHGMw+ZgBi6aiZjhKb/2nsmQzzr8G2RXOLw==",
       "dependencies": {
         "@apollo/cache-control-types": "^1.0.2",
-        "@apollo/federation-internals": "2.5.1"
+        "@apollo/federation-internals": "2.7.2"
       },
       "engines": {
         "node": ">=14.15.0"
@@ -3060,9 +3060,9 @@
       }
     },
     "node_modules/@types/uuid": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
-      "integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ=="
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA=="
     },
     "node_modules/@types/vscode": {
       "version": "1.80.0",
@@ -9778,9 +9778,9 @@
       }
     },
     "@apollo/federation-internals": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@apollo/federation-internals/-/federation-internals-2.5.1.tgz",
-      "integrity": "sha512-+TSt+GJWBeDiHRsLhaake2sYDni2yW3f4xRSq3+I6vsHs1GIcKgUbhq4fiDe61v6OXU1IckuI+TELRSMZNNh6A==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@apollo/federation-internals/-/federation-internals-2.7.2.tgz",
+      "integrity": "sha512-i+9mbw8UN6P+i5xpLxH3m8n3zqEBzoN8a1cct4yrab9loiZeIlxW8cLXzqglEMic++Sz9tai4L21ZY0GlW8ebg==",
       "requires": {
         "@types/uuid": "^9.0.0",
         "chalk": "^4.1.0",
@@ -9852,12 +9852,12 @@
       }
     },
     "@apollo/subgraph": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@apollo/subgraph/-/subgraph-2.5.1.tgz",
-      "integrity": "sha512-q6L9pbGL+R9yZpX4sQlf9YPwe/skbQB2pgOLV+H0m83nEwAx0eKgjuzNGqokb9YBYU23dv3kkItR3nHBw5RMUw==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@apollo/subgraph/-/subgraph-2.7.2.tgz",
+      "integrity": "sha512-n3N8HULcj0Mpegsgd9z4MK2oEbC4BVJFuhcrliNdpq+vlcmvOaEaHGMw+ZgBi6aiZjhKb/2nsmQzzr8G2RXOLw==",
       "requires": {
         "@apollo/cache-control-types": "^1.0.2",
-        "@apollo/federation-internals": "2.5.1"
+        "@apollo/federation-internals": "2.7.2"
       }
     },
     "@apollo/usage-reporting-protobuf": {
@@ -11971,9 +11971,9 @@
       }
     },
     "@types/uuid": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
-      "integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ=="
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA=="
     },
     "@types/vscode": {
       "version": "1.80.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@apollo/client": "^3.4.16",
     "@apollo/server": "^4.8.1",
-    "@apollo/subgraph": "^2.4.3",
+    "@apollo/subgraph": "^2.7.2",
     "@faker-js/faker": "^8.2.0",
     "@graphql-tools/mock": "^8.7.14",
     "@graphql-typed-document-node/core": "^3.2.0",
@@ -132,6 +132,13 @@
           ],
           "default": "",
           "description": "Specifies the rover config profile that should be used for GraphOS"
+        },
+        "apollo-workbench.graphRef": {
+          "type": [
+            "string"
+          ],
+          "default": "",
+          "description": "Specifies the Graph Ref that should be used for GraphOS with `rover dev`"
         },
         "apollo-workbench.startingServerPort": {
           "type": [

--- a/src/commands/local-supergraph-designs.ts
+++ b/src/commands/local-supergraph-designs.ts
@@ -362,7 +362,7 @@ export async function addSubgraph(item?: SubgraphSummaryTreeItem) {
   } else {
     const wbFile = FileProvider.instance.workbenchFileFromPath(wbFilePath);
     let schemaString =
-      'extend schema \n\t@link(url: "https://specs.apollo.dev/federation/v", import: ["@key"])\n\ntype Product @key(fields:"id") { \n\tid: ID!\n}';
+      'extend schema \n\t@link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@key"])\n\ntype Product @key(fields:"id") { \n\tid: ID!\n}';
     if (Object.keys(wbFile.subgraphs).length == 0) {
       schemaString += '\ntype Query {\n\tproducts: [Product]\n}';
     }
@@ -399,7 +399,7 @@ export async function addSubgraph(item?: SubgraphSummaryTreeItem) {
     await FileProvider.instance.writeWorkbenchConfig(wbFilePath, wbFile);
   }
 }
-// }
+
 export async function deleteSubgraph(item?: SubgraphTreeItem) {
   const wbFilePath = item ? item.wbFilePath : await whichDesign();
   if (!wbFilePath) return;

--- a/src/commands/local-supergraph-designs.ts
+++ b/src/commands/local-supergraph-designs.ts
@@ -362,7 +362,7 @@ export async function addSubgraph(item?: SubgraphSummaryTreeItem) {
   } else {
     const wbFile = FileProvider.instance.workbenchFileFromPath(wbFilePath);
     let schemaString =
-      'extend schema \n\t@link(url: "https://specs.apollo.dev/federation/v2.5", import: ["@key"])\n\ntype Product @key(fields:"id") { \n\tid: ID!\n}';
+      'extend schema \n\t@link(url: "https://specs.apollo.dev/federation/v", import: ["@key"])\n\ntype Product @key(fields:"id") { \n\tid: ID!\n}';
     if (Object.keys(wbFile.subgraphs).length == 0) {
       schemaString += '\ntype Query {\n\tproducts: [Product]\n}';
     }
@@ -628,7 +628,7 @@ export async function addFederationDirective(
   } else {
     await editor?.insertSnippet(
       new SnippetString(
-        `extend schema @link(url: "https://specs.apollo.dev/federation/v2.5", import: ["${directive}"])\n\n`,
+        `extend schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["${directive}"])\n\n`,
       ),
       new Position(0, 0),
     );

--- a/src/commands/local-supergraph-designs.ts
+++ b/src/commands/local-supergraph-designs.ts
@@ -668,7 +668,9 @@ export async function changeDesignFederationVersion(
   const wbFilePath = item.wbFilePath;
   if (wbFilePath) {
     const versions = [
-      '2.5.6',
+      '2.7.2',
+      '2.6.3',
+      '2.5.7',
       '2.4.13',
       '2.3.5',
       '2.2.3',
@@ -678,7 +680,7 @@ export async function changeDesignFederationVersion(
     ];
     const selectedVersion = await window.showQuickPick(versions, {
       title: 'Select Federation Version',
-      placeHolder: '=2.5.2',
+      placeHolder: '=2.7.2',
     });
     if (selectedVersion) {
       const wbFile = FileProvider.instance.workbenchFileFromPath(wbFilePath);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -320,13 +320,8 @@ export async function activate(context: ExtensionContext) {
                 await FileProvider.instance.refreshWorkbenchFileComposition(
                   wbFilePath,
                 );
-
-              if (composedSchema)
-                await Rover.instance.restartMockedSubgraph(
-                  subgraphName,
-                  wbFile.subgraphs[subgraphName],
-                );
-              else if (Rover.instance.primaryDevTerminal) {
+                
+              if (!composedSchema && Rover.instance.primaryDevTerminal) {
                 window.showErrorMessage(
                   `Stopping rover dev session because of invalid composition`,
                 );

--- a/src/workbench/file-system/ApolloConfig.ts
+++ b/src/workbench/file-system/ApolloConfig.ts
@@ -4,7 +4,7 @@ export class ApolloConfig {
   operations: { [name: string]: Operation } = {};
 
   constructor() {
-    this.federation_version = '=2.5.2';
+    this.federation_version = '=2.7.2';
   }
 
   public static copy(config: ApolloConfig) {

--- a/src/workbench/file-system/fileProvider.ts
+++ b/src/workbench/file-system/fileProvider.ts
@@ -438,6 +438,18 @@ export class FileProvider {
       resolve(homedir(), '.apollo-workbench', 'supergraph.yaml'),
     );
   }
+  async getTempWorkbenchFileAsync() {
+    const tempFile = await workspace.fs.readFile(
+      Uri.parse(
+        normalizePath(
+          resolve(homedir(), '.apollo-workbench', 'supergraph.yaml'),
+        ),
+      ),
+    );
+    const content = tempFile?.toString();
+
+    return load(tempFile?.toString()) as ApolloConfig;
+  }
 
   async writeWorkbenchConfig(
     path: string,
@@ -508,14 +520,15 @@ export class FileProvider {
             Uri.parse(directoryPath),
           );
           try {
-            const yaml = load(new TextDecoder().decode(yamlFile)) as ApolloConfig;
+            const yaml = load(
+              new TextDecoder().decode(yamlFile),
+            ) as ApolloConfig;
             if (yaml?.federation_version) {
               workbenchFiles.push(Uri.parse(directoryPath));
             }
           } catch (error) {
             console.log(`Error parsing ${directoryPath}\nError: ${error}`);
           }
-
         }
       }
 

--- a/src/workbench/file-system/fileProvider.ts
+++ b/src/workbench/file-system/fileProvider.ts
@@ -232,10 +232,10 @@ export class FileProvider {
                 Rover.instance.primaryDevTerminal != undefined
               ) {
                 //Need to restart any mocked subgraphs running with `rover dev`
-                Object.keys(wbFile.subgraphs).forEach((subgraphName) => {
+                Object.keys(wbFile.subgraphs).forEach(async (subgraphName) => {
                   const subgraph = wbFile.subgraphs[subgraphName];
                   if (subgraph.schema.mocks?.enabled) {
-                    Rover.instance.restartMockedSubgraph(
+                    await Rover.instance.restartMockedSubgraph(
                       subgraphName,
                       subgraph,
                     );

--- a/src/workbench/file-system/fileProvider.ts
+++ b/src/workbench/file-system/fileProvider.ts
@@ -468,6 +468,8 @@ export class FileProvider {
 
     if (shouldRefresh)
       StateManager.instance.localSupergraphTreeDataProvider.refresh();
+
+    await Rover.instance.tryRestartRoverDev(path);
   }
 
   workbenchFileByGraphName(name: string) {

--- a/src/workbench/rover.ts
+++ b/src/workbench/rover.ts
@@ -248,37 +248,20 @@ export class Rover {
   private subgraphState: { [subgraphName: string]: ApolloServer } = {};
   ports: number[] = [];
 
-  // private getNextAvailablePort() {
-  //   let port = StateManager.settings_startingServerPort;
-  //   while (this.subgraphState[port]) port++;
-
-  //   return port;
-  // }
-
   async restartMockedSubgraph(subgraphName: string, subgraph: Subgraph) {
     if (!this.primaryDevTerminal) return;
 
     log(`Restarting subgraph: ${subgraphName}`);
 
-    // let port = 0;
-    // for (const sn in this.portMapping)
-    //   if (sn == subgraphName) port = this.portMapping[sn];
-
-    // if (port != 0) {
       log(`Stopping subgraph: ${subgraphName}`);
       this.stopMockedSubgraph(subgraphName);
       await this.startMockedSubgraph(subgraphName, subgraph);
-    // }
   }
 
   async startMockedSubgraph(
     subgraphName: string,
     subgraph: Subgraph,
-    // port?: number,
   ) {
-    // if (!port)
-    //   port = this.portMapping[subgraphName] ?? this.getNextAvailablePort();
-
     try {
       const schemaPath =
         subgraph.schema.workbench_design ?? subgraph.schema.file ?? '';
@@ -371,12 +354,9 @@ export class Rover {
         context: async ({ req }) => ({ ...req.headers }),
       });
 
-      // .then(({ url }) => {
         log(`\t${subgraphName} mock server running at ${url}`);
         this.subgraphState[subgraphName] = server;
-        //Set the port and server to local state
-        // this.portMapping[subgraphName] = port;
-      // });
+
       return url;
     } catch (err: any) {
       this.subgraphState[subgraphName]?.stop();
@@ -501,6 +481,12 @@ export class Rover {
     }
     if (StateManager.settings_routerVersion) {
       command = `APOLLO_ROVER_DEV_ROUTER_VERSION=${StateManager.settings_routerVersion} ${command}`;
+    }
+    if (StateManager.settings_graphRef) {
+      command = `APOLLO_GRAPH_REF=${StateManager.settings_graphRef} ${command}`;
+    }
+    if(StateManager.settings_roverConfigProfile){
+      command = `${command} --profile=${StateManager.settings_roverConfigProfile}`;
     }
     this.primaryDevTerminal = window.createTerminal(wbFilePath);
     this.primaryDevTerminal.show();

--- a/src/workbench/stateManager.ts
+++ b/src/workbench/stateManager.ts
@@ -139,6 +139,16 @@ export class StateManager {
       .getConfiguration('apollo-workbench')
       .get('local-designs.expandOperationsByDefault') as boolean;
   }
+  static get settings_graphRef(): string {
+    return workspace
+      .getConfiguration('apollo-workbench')
+      .get('graphRef') as string;
+  }
+  static set settings_graphRef(profile: string) {
+    workspace
+      .getConfiguration('apollo-workbench')
+      .update('graphRef', profile);
+  }
   static get settings_roverConfigProfile(): string {
     return workspace
       .getConfiguration('apollo-workbench')


### PR DESCRIPTION
Introducing dynamic ports to mocked subgraphs ended up breaking hot-reload because the updated url wasn't updating in `rover dev`. We fixed this by changing the port creation to a one time determination and then we save that state to re-use  during the entire `rover dev` session. 

Some additional fixes for mocking were added along with a `apollo-workbench.graphRef` setting to use enterprise features with `rover dev`. All you need to do is ensure `rover` is logged in with an enterprise key and set the `apollo-workbench.graphRef` to your enterprise graph, then it just works! If you use a profile for your rover keys, there is a workbench setting for that as well. 