### PR TITLE
Use `apolloApiUrl` for all of `rover` commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Apollo Workbench VSCode 3.3.10
+
+- Fix `apolloApiUrl` setting to work with all `rover` commands. This is primarily for internal Apollo debugging purposes against pre-prod environments of GraphOS.
+
 ## Apollo Workbench VSCode 3.3.9
 
 - Create `graphRef` setting - when using the play button to start a design locally, `rover dev` needs to pass a graph ref to an enterprise graph in GraphOS. This setting enables a user to set the name of their graph for the extension to work with.

--- a/package.json
+++ b/package.json
@@ -90,9 +90,10 @@
       "properties": {
         "apollo-workbench.apolloApiUrl": {
           "type": [
-            "string"
+            "string",
+            "null"
           ],
-          "default": "https://api.apollographql.com/graphql",
+          "default": null,
           "description": "Specifies the url endpoint to be used for the Apollo GraphOS Platform API"
         },
         "apollo-workbench.apolloOrg": {

--- a/src/graphql/graphClient.ts
+++ b/src/graphql/graphClient.ts
@@ -40,9 +40,12 @@ const getGraphOperations = gql`
 
 export async function isValidKey(apiKey: string) {
   const result = await toPromise(
-    execute(createLink(getOperationName(CheckUserApiKeyDocument) ?? '', apiKey), {
-      query: CheckUserApiKeyDocument,
-    }),
+    execute(
+      createLink(getOperationName(CheckUserApiKeyDocument) ?? '', apiKey),
+      {
+        query: CheckUserApiKeyDocument,
+      },
+    ),
   );
   const data = result.data as CheckUserApiKeyQuery;
   if (data.me?.id) return true;
@@ -107,12 +110,13 @@ function createLink(
 
   if (StateManager.settings_apolloOrg) headers['apollo-sudo'] = 'true';
 
-  const uri =
+  let uri =
     operationName == 'GraphOperations'
       ? 'https://graphql.api.apollographql.com/api/graphql'
-      : (vscode.workspace
-          .getConfiguration('apollo-workbench')
-          .get('apolloApiUrl') as string);
+      : 'https://api.apollographql.com/graphql';
+
+  if (StateManager.settings_apolloApiUrl)
+    uri = StateManager.settings_apolloApiUrl;
 
   return createHttpLink({
     fetch: fetch as any,

--- a/src/workbench/rover.ts
+++ b/src/workbench/rover.ts
@@ -54,15 +54,10 @@ export class Rover {
     if (StateManager.settings_roverConfigProfile) {
       cmd = `${cmd} --profile=${StateManager.settings_roverConfigProfile}`;
     }
-    // TODO: Verify this doesn't actually work on mac, it probably can be removed
-    // else if (StateManager.instance.globalState_userApiKey) {
-    //   if (process.platform != 'win32')
-    //     cmd = `set APOLLO_KEY=${StateManager.instance.globalState_userApiKey};${cmd}`;
-    //   else
-    //     cmd = `APOLLO_KEY=${StateManager.instance.globalState_userApiKey} ${cmd}`;
-    // }
 
-    if (shouldLog) this.logCommand(cmd);
+    if(StateManager.settings_apolloApiUrl) {
+      cmd = `APOLLO_REGISTRY_URL=${StateManager.settings_apolloApiUrl} ${cmd}`;
+    }
 
     if (process.platform !== 'win32') {
       //workaround, source rover binary from install location
@@ -73,6 +68,7 @@ export class Rover {
       //  TODO: Make this a osx specific setting in VSCode, then test in Windows
       cmd = `source /$HOME/.rover/env && ${cmd}`;
     }
+    if (shouldLog) this.logCommand(cmd);
 
     return await new Promise<string | undefined>((resolve, reject) => {
       try {
@@ -507,6 +503,9 @@ export class Rover {
     }
     if (StateManager.settings_roverConfigProfile) {
       command = `${command} --profile=${StateManager.settings_roverConfigProfile}`;
+    }
+    if(StateManager.settings_apolloApiUrl){
+      command = `APOLLO_REGISTRY_URL=${StateManager.settings_apolloApiUrl} ${command}`;
     }
     this.primaryDevTerminal = window.createTerminal(wbFilePath);
     this.primaryDevTerminal.show();

--- a/src/workbench/stateManager.ts
+++ b/src/workbench/stateManager.ts
@@ -154,6 +154,11 @@ export class StateManager {
       .getConfiguration('apollo-workbench')
       .get('roverConfigProfile') as string;
   }
+  static get settings_apolloApiUrl(): string {
+    return workspace
+      .getConfiguration('apollo-workbench')
+      .get('apolloApiUrl') as string;
+  }
   static set settings_roverConfigProfile(profile: string) {
     workspace
       .getConfiguration('apollo-workbench')


### PR DESCRIPTION
Primary use case if for the `rover subgraph fetch` command to work against pre-prod GraphOS environments. This is for internal Apollo debugging/usage purposes. 